### PR TITLE
created todo comment for stratification fix

### DIFF
--- a/notebooks/binary_test.ipynb
+++ b/notebooks/binary_test.ipynb
@@ -55,6 +55,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "X.columns"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "y = bc[\"target\"]"
    ]
   },
@@ -97,6 +106,7 @@
     "    estimator=lr,\n",
     "    kfold=kfold,\n",
     "    stratify_y=True,\n",
+    "    stratify_cols=['mean radius', 'mean texture', 'mean perimeter', 'mean area']\n",
     "    grid=tuned_parameters,\n",
     "    randomized_grid=True,\n",
     "    n_iter=40,\n",

--- a/notebooks/binary_test.ipynb
+++ b/notebooks/binary_test.ipynb
@@ -55,7 +55,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "X.columns"
+    "X"
    ]
   },
   {
@@ -106,7 +106,7 @@
     "    estimator=lr,\n",
     "    kfold=kfold,\n",
     "    stratify_y=True,\n",
-    "    stratify_cols=['mean radius', 'mean texture', 'mean perimeter', 'mean area']\n",
+    "    stratify_cols=[\"mean radius\"],\n",
     "    grid=tuned_parameters,\n",
     "    randomized_grid=True,\n",
     "    n_iter=40,\n",

--- a/notebooks/regression_test.ipynb
+++ b/notebooks/regression_test.ipynb
@@ -26,6 +26,25 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "df1 = pd.DataFrame({\"A\": [1, 2], \"B\": [3, 4]})\n",
+    "df2 = pd.DataFrame({\"Y\": [5, 6]})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pd.concat([df1, df2], axis=1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "# `base_path`` represents the parent directory of your current working directory\n",
     "base_path = os.path.join(os.pardir)\n",
     "\n",

--- a/src/model_tuner/model_tuner_utils.py
+++ b/src/model_tuner/model_tuner_utils.py
@@ -947,9 +947,6 @@ class Model:
         #     X = X.join(self.dropped_strat_cols)
         # Determine the stratify parameter based on stratify and stratify_cols
 
-        ## TODO: need to either consolidate stratification into one input or
-        ## alow for simultaneous usage of stratify_cols and stratify_y inputs.
-
         if stratify_cols and stratify_y:
             # Creating stratification columns out of stratify_cols list
             stratify_key = pd.concat([X[stratify_cols], y], axis=1)
@@ -1204,7 +1201,7 @@ def kfold_split(
         return kf
 
 
-def get_cross_validate(classifier, X, y, kf, stratify=False, scoring=["roc_auc"]):
+def get_cross_validate(classifier, X, y, kf, scoring=["roc_auc"]):
     return cross_validate(
         classifier,
         X,

--- a/src/model_tuner/model_tuner_utils.py
+++ b/src/model_tuner/model_tuner_utils.py
@@ -941,6 +941,10 @@ class Model:
         # if calibrate:
         #     X = X.join(self.dropped_strat_cols)
         # Determine the stratify parameter based on stratify and stratify_cols
+
+        ## TODO: need to either consolidate stratification into one input or 
+        ## alow for simultaneous usage of stratify_cols and stratify_y inputs.
+        
         if stratify_cols:
             # Creating stratification columns out of stratify_cols list
             stratify_key = X[stratify_cols]


### PR DESCRIPTION
**Description:**

Currently, the `train_val_test_split` method allows for stratification either by y (`stratify_y`) or by specified columns (`stratify_cols`), but not both at the same time. There are use cases where stratification by both the target variable (y) and specific columns is necessary to ensure a balanced and representative split across different data segments.

**Proposed Enhancement:**

Modify the method to support simultaneous stratification by both y and `stratify_cols`. This can be achieved by combining the stratification keys or implementing logic that ensures both y and the specified columns are considered during the stratification process.

**Current Method Implementation:**

```python
def train_val_test_split(
    self,
    X,
    y,
    stratify_y,
    train_size,
    validation_size,
    test_size,
    random_state,
    stratify_cols,
    calibrate,
):

    # if calibrate:
    #     X = X.join(self.dropped_strat_cols)
    # Determine the stratify parameter based on stratify and stratify_cols
    if stratify_cols:
        # Creating stratification columns out of stratify_cols list
        stratify_key = X[stratify_cols]
    elif stratify_y:
        stratify_key = y
    else:
        stratify_key = None

    if self.drop_strat_feat:
        self.dropped_strat_cols = X[self.drop_strat_feat]
        X = X.drop(columns=self.drop_strat_feat)

    X_train, X_valid_test, y_train, y_valid_test = train_test_split(
        X,
        y,
        test_size=1 - train_size,
        stratify=stratify_key,  # Use stratify_key here
        random_state=random_state,
    )

    # Determine the proportion of validation to test size in the remaining dataset
    proportion = test_size / (validation_size + test_size)

    if stratify_cols:
        strat_key_val_test = X_valid_test[stratify_cols]
    elif stratify_y:
        strat_key_val_test = y_valid_test
    else:
        strat_key_val_test = None

    # Further split (validation + test) set into validation and test sets
    X_valid, X_test, y_valid, y_test = train_test_split(
        X_valid_test,
        y_valid_test,
        test_size=proportion,
        stratify=strat_key_val_test,
        random_state=random_state,
    )

    return X_train, X_valid, X_test, y_train, y_valid, y_test
```

