### PR TITLE
corrected labels and pos args in conf_mat

### DIFF
--- a/src/model_tuner/model_tuner_utils.py
+++ b/src/model_tuner/model_tuner_utils.py
@@ -200,7 +200,7 @@ class Model:
         self.threshold = {score: 0 for score in self.scoring}
         self.beta = 2
         self.trained = trained
-        self.labels = ["tp", "fn", "fp", "tn"]
+        self.labels = ["tn", "fp", "fn", "tp"]
         self.xgboost_early = xgboost_early
         self.custom_scorer = custom_scorer
 
@@ -1214,7 +1214,6 @@ def get_cross_validate(classifier, X, y, kf, scoring=["roc_auc"]):
 
 
 def _confusion_matrix_print(conf_matrix, labels):
-
     max_length = max(len(str(conf_matrix.max())), 2)
     border = "-" * 80
     print(border)
@@ -1222,13 +1221,12 @@ def _confusion_matrix_print(conf_matrix, labels):
     print(f"{'':>12}{'Pos':>{max_length+1}}{'Neg':>{max_length+3}}")
     print(border)
     print(
-        f"Actual: Pos {conf_matrix[0,0]:>{max_length}} ({labels[0]})  {conf_matrix[0,1]:>{max_length}} ({labels[1]})"
+        f"Actual: Pos {conf_matrix[1,1]:>{max_length}} ({labels[3]})  {conf_matrix[1,0]:>{max_length}} ({labels[2]})"
     )
     print(
-        f"{'':>8}Neg {conf_matrix[1,0]:>{max_length}} ({labels[2]})  {conf_matrix[1,1]:>{max_length}} ({labels[3]})"
+        f"{'':>8}Neg {conf_matrix[0,1]:>{max_length}} ({labels[1]})  {conf_matrix[0,0]:>{max_length}} ({labels[0]})"
     )
     print(border)
-
 
 ################################################################################
 


### PR DESCRIPTION
**Description:**

This pull request resolves the issue of misaligned **"Pos"** and **"Neg"** labels in the confusion matrix printout. The previous implementation incorrectly labeled the confusion matrix elements, leading to confusion in interpreting the results. This fix ensures that the labels correctly align with the corresponding values in the confusion matrix.

**Related Issue:**
Closes [Issue #32](https://github.com/uclamii/model_tuner/issues/32)

Previously, the constructor had the following labels:

```python
self.labels = ["tp", "fn", "fp", "tn"]
```
**Changes Made:**
- Updated the self.labels list to correctly reflect the confusion matrix elements

```python
self.labels = ["tn", "fp", "fn", "tp"]
```

- Modified the `_confusion_matrix_print` function to properly align the **"Pos"** and **"Neg"** labels with the corresponding values in the confusion matrix:

```python
def _confusion_matrix_print(conf_matrix, labels):
    max_length = max(len(str(conf_matrix.max())), 2)
    border = "-" * 80
    print(border)
    print(f"{'':>10}Predicted:")
    print(f"{'':>12}{'Pos':>{max_length+1}}{'Neg':>{max_length+3}}")
    print(border)
    print(
        f"Actual: Pos {conf_matrix[1,1]:>{max_length}} ({labels[3]})  {conf_matrix[1,0]:>{max_length}} ({labels[2]})"
    )
    print(
        f"{'':>8}Neg {conf_matrix[0,1]:>{max_length}} ({labels[1]})  {conf_matrix[0,0]:>{max_length}} ({labels[0]})"
    )
    print(border)
```

If you try and rerun the `return_metrics` on the example [AIDS Clinical Trials Notebook](https://colab.research.google.com/drive/12XywbGBiwlZIbi0C3JKu9NOQPPRgVwcp?authuser=1), you will see that the issue is fixed, and the correct labels will be provided:

```python
Confusion matrix on set provided: 
--------------------------------------------------------------------------------
          Predicted:
             Pos   Neg
--------------------------------------------------------------------------------
Actual: Pos  64 (tp)   40 (fn)
        Neg  20 (fp)  304 (tn)
```
