### PR TITLE
Catboost support

### DIFF
--- a/src/model_tuner/model_tuner_utils.py
+++ b/src/model_tuner/model_tuner_utils.py
@@ -37,44 +37,44 @@ from sklearn.linear_model import LogisticRegression
 | Scoring                        | Function                             | Comment                        |
 |--------------------------------|--------------------------------------|--------------------------------|
 | Classification                 |                                      |                                |
-| `accuracy`                     | metrics.accuracy_score               |                                |
-| `balanced_accuracy`            | metrics.balanced_accuracy_score      |                                |
-| `average_precision`            | metrics.average_precision_score      |                                |
-| `neg_brier_score`              | metrics.brier_score_loss             |                                |
-| `f1`                           | metrics.f1_score                     | for binary targets             |
-| `f1_micro`                     | metrics.f1_score                     | micro-averaged                 |
-| `f1_macro`                     | metrics.f1_score                     | macro-averaged                 |
-| `f1_weighted`                  | metrics.f1_score                     | weighted average               |
-| `f1_samples`                   | metrics.f1_score                     | by multilabel sample           |
-| `neg_log_loss`                 | metrics.log_loss                     | requires predict_proba support |
-| `precision` etc.               | metrics.precision_score              | suffixes apply as with `f1`    |
-| `recall` etc.                  | metrics.recall_score                 | suffixes apply as with `f1`    |
-| `jaccard` etc.                 | metrics.jaccard_score                | suffixes apply as with `f1`    |
-| `roc_auc`                      | metrics.roc_auc_score                |                                |
-| `roc_auc_ovr`                  | metrics.roc_auc_score                |                                |
-| `roc_auc_ovo`                  | metrics.roc_auc_score                |                                |
-| `roc_auc_ovr_weighted`         | metrics.roc_auc_score                |                                |
-| `roc_auc_ovo_weighted`         | metrics.roc_auc_score                |                                |
+| ‘accuracy’                    | metrics.accuracy_score               |                                |
+| ‘balanced_accuracy’           | metrics.balanced_accuracy_score      |                                |
+| ‘average_precision’           | metrics.average_precision_score      |                                |
+| ‘neg_brier_score’             | metrics.brier_score_loss             |                                |
+| ‘f1’                          | metrics.f1_score                     | for binary targets             |
+| ‘f1_micro’                    | metrics.f1_score                     | micro-averaged                 |
+| ‘f1_macro’                    | metrics.f1_score                     | macro-averaged                 |
+| ‘f1_weighted’                 | metrics.f1_score                     | weighted average               |
+| ‘f1_samples’                  | metrics.f1_score                     | by multilabel sample           |
+| ‘neg_log_loss’                | metrics.log_loss                     | requires predict_proba support |
+| ‘precision’etc.               | metrics.precision_score              | suffixes apply as with ‘f1’   |
+| ‘recall’etc.                  | metrics.recall_score                 | suffixes apply as with ‘f1’   |
+| ‘jaccard’etc.                 | metrics.jaccard_score                | suffixes apply as with ‘f1’   |
+| ‘roc_auc’                     | metrics.roc_auc_score                |                                |
+| ‘roc_auc_ovr’                 | metrics.roc_auc_score                |                                |
+| ‘roc_auc_ovo’                 | metrics.roc_auc_score                |                                |
+| ‘roc_auc_ovr_weighted’        | metrics.roc_auc_score                |                                |
+| ‘roc_auc_ovo_weighted’        | metrics.roc_auc_score                |                                |
 | Clustering                     |                                      |                                |
-| `adjusted_mutual_info_score`   | metrics.adjusted_mutual_info_score   |                                |
-| `adjusted_rand_score`          | metrics.adjusted_rand_score          |                                |
-| `completeness_score`           | metrics.completeness_score           |                                |
-| `fowlkes_mallows_score`        | metrics.fowlkes_mallows_score        |                                |
-| `homogeneity_score`            | metrics.homogeneity_score            |                                |
-| `mutual_info_score`            | metrics.mutual_info_score            |                                |
-| `normalized_mutual_info_score` | metrics.normalized_mutual_info_score |                                |
-| `v_measure_score`              | metrics.v_measure_score              |                                |
+| ‘adjusted_mutual_info_score’  | metrics.adjusted_mutual_info_score   |                                |
+| ‘adjusted_rand_score’         | metrics.adjusted_rand_score          |                                |
+| ‘completeness_score’          | metrics.completeness_score           |                                |
+| ‘fowlkes_mallows_score’       | metrics.fowlkes_mallows_score        |                                |
+| ‘homogeneity_score’           | metrics.homogeneity_score            |                                |
+| ‘mutual_info_score’           | metrics.mutual_info_score            |                                |
+| ‘normalized_mutual_info_score’| metrics.normalized_mutual_info_score |                                |
+| ‘v_measure_score’             | metrics.v_measure_score              |                                |
 | Regression                     |                                      |                                |
-| `explained_variance`           | metrics.explained_variance_score     |                                |
-| `max_error`                    | metrics.max_error                    |                                |
-| `neg_mean_absolute_error`      | metrics.mean_absolute_error          |                                |
-| `neg_mean_squared_error`       | metrics.mean_squared_error           |                                |
-| `neg_root_mean_squared_error`  | metrics.mean_squared_error           |                                |
-| `neg_mean_squared_log_error`   | metrics.mean_squared_log_error       |                                |
-| `neg_median_absolute_error`    | metrics.median_absolute_error        |                                |
-| `r2`                           | metrics.r2_score                     |                                |
-| `neg_mean_poisson_deviance`    | metrics.mean_poisson_deviance        |                                |
-| `neg_mean_gamma_deviance`      | metrics.mean_gamma_deviance          |                                |
+| ‘explained_variance’          | metrics.explained_variance_score     |                                |
+| ‘max_error’                   | metrics.max_error                    |                                |
+| ‘neg_mean_absolute_error’     | metrics.mean_absolute_error          |                                |
+| ‘neg_mean_squared_error’      | metrics.mean_squared_error           |                                |
+| ‘neg_root_mean_squared_error’ | metrics.mean_squared_error           |                                |
+| ‘neg_mean_squared_log_error’  | metrics.mean_squared_log_error       |                                |
+| ‘neg_median_absolute_error’   | metrics.median_absolute_error        |                                |
+| ‘r2’                          | metrics.r2_score                     |                                |
+| ‘neg_mean_poisson_deviance’   | metrics.mean_poisson_deviance        |                                |
+| ‘neg_mean_gamma_deviance’     | metrics.mean_gamma_deviance          |                                |
 
 """
 

--- a/src/model_tuner/model_tuner_utils.py
+++ b/src/model_tuner/model_tuner_utils.py
@@ -962,24 +962,21 @@ class Model:
         calibrate,
     ):
 
-        # if calibrate:
-        #     X = X.join(self.dropped_strat_cols)
-        # Determine the stratify parameter based on stratify and stratify_cols
 
-        if stratify_cols and stratify_y:
+        if stratify_cols is not None and stratify_y:
             # Creating stratification columns out of stratify_cols list
             if type(stratify_cols) == pd.DataFrame:
                 stratify_key = pd.concat([stratify_cols, y], axis=1)
             else:
                 stratify_key = pd.concat([X[stratify_cols], y], axis=1)
-        elif stratify_cols:
+        elif stratify_cols is not None:
             stratify_key = X[stratify_cols]
         elif stratify_y:
             stratify_key = y
         else:
             stratify_key = None
 
-        if stratify_cols:
+        if stratify_cols is not None:
             # stratify_key = stratify_key.copy()
             stratify_key = stratify_key.fillna("")
 
@@ -999,7 +996,7 @@ class Model:
         # Determine the proportion of validation to test size in the remaining dataset
         proportion = test_size / (validation_size + test_size)
 
-        if stratify_cols and stratify_y:
+        if stratify_cols is not None and stratify_y:
             # Creating stratification columns out of stratify_cols list
             if type(stratify_cols) == pd.DataFrame:
                 strat_key_val_test = pd.concat(
@@ -1016,7 +1013,7 @@ class Model:
         else:
             strat_key_val_test = None
 
-        if stratify_cols:
+        if stratify_cols is not None:
             strat_key_val_test = strat_key_val_test.fillna("")
 
         # Further split (validation + test) set into validation and test sets

--- a/src/model_tuner/model_tuner_utils.py
+++ b/src/model_tuner/model_tuner_utils.py
@@ -1006,7 +1006,7 @@ class Model:
                 strat_key_val_test = pd.concat(
                     [X_valid_test[stratify_cols], y_valid_test], axis=1
                 )
-        elif stratify_cols:
+        elif stratify_cols is not None:
             strat_key_val_test = X_valid_test[stratify_cols]
         elif stratify_y:
             strat_key_val_test = y_valid_test


### PR DESCRIPTION
- Fixing stratify cols bug: where y was used instead of `y_valid_test` causing length mismatch
- Catboost support added so that we can now use catboost early stopping (resetting estimators + try and except for catboost best iteration extraction) 
- Fixing ambiguity with the truth value of a list / dataframe error. 