### PR TITLE
Fixed Requirement Versions

### DIFF
--- a/notebooks/xgb_early_bootstrap_test.py
+++ b/notebooks/xgb_early_bootstrap_test.py
@@ -3,8 +3,6 @@ import numpy as np
 import os
 import sys
 
-sys.path.append("src")
-
 from sklearn.datasets import make_classification
 
 from sklearn.datasets import load_breast_cancer

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,7 @@ pandas==2.2.2
 scikit-learn==1.5.1
 scipy==1.14.0
 tqdm==4.66.4
+-e .
+# companion libs used with model tuner
+catboost==1.2.7
+xgboost==2.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-joblib>=1.3.2
-numpy>=1.21.6
-pandas>=1.3.5
-scikit-learn>=1.0.2
-scipy>=1.7.3
-tqdm>=4.66.4
+joblib==1.4.2
+numpy==1.26.4
+pandas==2.2.2
+scikit-learn==1.5.1
+scipy==1.14.0
+tqdm==4.66.4

--- a/setup.py
+++ b/setup.py
@@ -24,11 +24,11 @@ setup(
     ],  # Classifiers for the package
     python_requires=">=3.7",  # Minimum version of Python required
     install_requires=[
-        "joblib>=1.3.2",
-        "numpy>=1.21.6",
-        "pandas>=1.3.5",
-        "scikit-learn>=1.0.2",
-        "scipy>=1.7.3",
-        "tqdm>=4.66.4",
+        "joblib==1.4.2",
+        "numpy==1.26.4",
+        "pandas==2.2.2",
+        "scikit-learn==1.5.1",
+        "scipy==1.14.0",
+        "tqdm==4.66.4",
     ],
 )


### PR DESCRIPTION
Updated the setup.py and requirements.txt to contain exact versions rather than anything above these versions. I think maybe we should include a range e.g. pandas 1.3.5 < pandas 2.2.2.

We can do this by changing the current fixed versions to this:

```pandas>=1.3.5,<2.2.2```