### PR TITLE
added flexibility between bool and None for strat param

### DIFF
--- a/src/model_tuner/model_tuner_utils.py
+++ b/src/model_tuner/model_tuner_utils.py
@@ -1497,6 +1497,12 @@ def train_val_test_split(
     stratify_cols=None,
 ):
 
+    # Standardize stratification parameters
+    if stratify_y is False:
+        stratify_y = None
+    if stratify_cols is False:
+        stratify_cols = None
+
     if stratify_cols is not None and stratify_y is not None:
         if type(stratify_cols) == pd.DataFrame:
             stratify_key = pd.concat([stratify_cols, y], axis=1)


### PR DESCRIPTION
This pull request enhances the `train_val_test_split` function by standardizing the handling of stratification parameters `stratify_y` and `stratify_cols`. Previously, passing `stratify_y=False` or `stratify_cols=False` did not disable stratification as users might expect. This fix ensures that both parameters interpret False as disabling stratification, thereby improving the function's usability and intuitiveness as follows:

```python
if stratify_y is False:
    stratify_y = None
if stratify_cols is False:
    stratify_cols = None
```