### PR TITLE
Enforce Required model_type Parameter in Model Class

### DIFF
--- a/src/model_tuner/model_tuner_utils.py
+++ b/src/model_tuner/model_tuner_utils.py
@@ -93,6 +93,7 @@ class Model:
         name,
         estimator_name,
         estimator,
+        model_type,
         calibrate=False,
         kfold=False,
         imbalance_sampler=None,
@@ -112,7 +113,6 @@ class Model:
         pipeline_steps=[],
         boost_early=False,
         feature_selection=False,
-        model_type="classification",
         class_labels=None,
         multi_label=False,
         calibration_method="sigmoid",  # 04_27_24 --> added calibration method
@@ -166,8 +166,6 @@ class Model:
             self.grid = grid
         else:
             self.grid = ParameterGrid(grid)
-        if scoring == ["roc_auc"] and model_type == "regression":
-            scoring == ["r2"]
         self.kf = None
         self.xval_output = None
         self.stratify_y = stratify_y

--- a/src/model_tuner/model_tuner_utils.py
+++ b/src/model_tuner/model_tuner_utils.py
@@ -119,6 +119,11 @@ class Model:
         custom_scorer=[],
         bayesian=False,
     ):
+
+        # Check if model_type is provided and valid
+        if model_type not in ["classification", "regression"]:
+            raise ValueError("You must specify model_type as either 'classification' or 'regression'.")
+
         self.name = name
         self.estimator_name = estimator_name
         self.calibrate = calibrate


### PR DESCRIPTION
This PR enforces the specification of the `model_type` parameter (`classification` or `regression`) when creating an instance of the `Model` class. Previously, `model_type` defaulted to `"classification"`, but this could lead to unintended behavior if the user did not explicitly specify the type of model.

## Changes
Removed Default Value for `model_type`:

- `model_type` is now a required parameter in the `__init__` method of the `Model` class. Users must specify it when instantiating the class.
- Added Validation Check for `model_type`:
  - A simple `ValueError` is raised if `model_type` is not `"classification"` or `"regression"`, ensuring that the parameter is set to an accepted value.

```python
  # Check if model_type is provided and valid
  if model_type not in ["classification", "regression"]:
      raise ValueError("You must specify model_type as either 'classification' or 'regression'.")
```