### PR TITLE
Handle Missing pipeline_steps When Using imbalance_sampler

### DIFF
--- a/notebooks/lr_smote_test.py
+++ b/notebooks/lr_smote_test.py
@@ -1,0 +1,130 @@
+import pandas as pd
+import numpy as np
+import os
+import sys
+
+from sklearn.datasets import make_classification
+
+from sklearn.datasets import load_breast_cancer
+from imblearn.over_sampling import SMOTE
+
+from functions import *
+
+from model_tuner.model_tuner_utils import Model
+from model_tuner.bootstrapper import evaluate_bootstrap_metrics
+from model_tuner.pickleObjects import dumpObjects, loadObjects
+from sklearn.linear_model import LogisticRegression
+
+
+from ucimlrepo import fetch_ucirepo
+
+# fetch dataset
+aids_clinical_trials_group_study_175 = fetch_ucirepo(id=890)
+
+
+aids_clinical_trials_group_study_175.data
+
+# data (as pandas dataframes)
+X = aids_clinical_trials_group_study_175.data.features
+
+indices = [
+    1024,
+    1,
+    387,
+    12,
+    1164,
+    1548,
+    1423,
+    272,
+    22,
+    152,
+    30,
+    2122,
+    33,
+    675,
+    1829,
+    1321,
+    810,
+    45,
+    1847,
+    1976,
+    55,
+    60,
+    1731,
+    67,
+    1354,
+    463,
+    213,
+    345,
+    2137,
+    606,
+    96,
+    100,
+    234,
+    120,
+    890,
+]
+
+X["gender"].iloc[indices] = np.nan
+
+
+y = aids_clinical_trials_group_study_175.data.targets
+
+joined_data = pd.merge(X, y, left_index=True, right_index=True)
+
+joined_data = joined_data.dropna()
+
+y = joined_data["cid"]
+
+X = joined_data.drop(columns=["cid"])
+
+lr = LogisticRegression(class_weight="balanced", max_iter=1000)
+
+estimator_name = "lg"
+# Set the parameters by cross-validation
+tuned_parameters = [
+    {
+        estimator_name + "__C": np.logspace(-4, 0, 3),
+    }
+]
+kfold = False
+calibrate = False
+
+
+model = Model(
+    name="Logistic Regression",
+    estimator_name=estimator_name,
+    model_type="classification",
+    calibrate=calibrate,
+    estimator=lr,
+    kfold=kfold,
+    stratify_y=True,
+    stratify_cols=["gender"],
+    grid=tuned_parameters,
+    randomized_grid=True,
+    n_iter=40,
+    scoring=["roc_auc"],
+    n_splits=10,
+    n_jobs=-2,
+    random_state=42,
+    imbalance_sampler=SMOTE(),
+)
+
+
+model.grid_search_param_tuning(X, y)
+
+X_train, y_train = model.get_train_data(X, y)
+X_test, y_test = model.get_test_data(X, y)
+X_valid, y_valid = model.get_valid_data(X, y)
+
+model.fit(X_train, y_train)
+
+print("Validation Metrics")
+model.return_metrics(X_valid, y_valid)
+print("Test Metrics")
+model.return_metrics(X_test, y_test)
+
+y_prob = model.predict_proba(X_test)
+
+### F1 Weighted
+y_pred = model.predict(X_test, optimal_threshold=True)

--- a/src/model_tuner/model_tuner_utils.py
+++ b/src/model_tuner/model_tuner_utils.py
@@ -224,7 +224,6 @@ class Model:
             for name, transformer in pipeline.steps
             if name.startswith("preprocess_")
         ]
-        # Create a new pipeline with just the preprocessing steps
         return self.PipelineClass(preprocessing_steps)
 
     def pipeline_assembly(self):
@@ -403,7 +402,11 @@ class Model:
 
         resampler_test = clone(self.estimator.named_steps["resampler"])
 
-        X_train_preproc = preproc_test.fit_transform(X_train)
+        ### Only apply the preprocessing when there are valid pipeline steps
+        if preproc_test:
+            X_train_preproc = preproc_test.fit_transform(X_train)
+        else:
+            X_train_preproc = X_train
 
         _, y_res = resampler_test.fit_resample(X_train_preproc, y_train)
 
@@ -418,7 +421,6 @@ class Model:
                 if self.calibrate:
                     # reset estimator in case of calibrated model
                     self.reset_estimator()
-                    ### FIXING CODE: More efficient by removing unnecessary fit
 
                     classifier = self.estimator.set_params(
                         **self.best_params_per_score[self.scoring[0]]["params"]

--- a/src/model_tuner/model_tuner_utils.py
+++ b/src/model_tuner/model_tuner_utils.py
@@ -148,7 +148,7 @@ class Model:
             self.PipelineClass = Pipeline
 
         self.pipeline_steps = pipeline_steps
-        if self.pipeline_steps:
+        if self.pipeline_steps or self.imbalance_sampler:
             self.pipeline_assembly()
         else:
             self.estimator = self.PipelineClass(


### PR DESCRIPTION
Certain models, such as `XGBoost`, do not require imputation or scaling, making the inclusion of `pipeline_steps` unnecessary. However, omitting `pipeline_steps` while specifying an `imbalance_sampler` (e.g., SMOTE()) causes a `KeyError`, as shown below:

```python
KeyError: 'resampler'
```

**Proposed Solution**
Update the code logic to handle cases where pipeline_steps is omitted. Specifically:

1. Ensure `imbalance_sampler` functionality does not depend on the presence of `pipeline_steps`.
2. Add a check to gracefully handle scenarios where `pipeline_steps` is not explicitly provided.

