### PR TITLE
removed extra input from xgb_early_test.py

### DIFF
--- a/notebooks/xgb_early_test.py
+++ b/notebooks/xgb_early_test.py
@@ -44,7 +44,6 @@ calibrate = False
 
 model = Model(
     name="XGBoost Early",
-    model_type="classification",
     estimator_name=estimator_name,
     model_type="classification",
     calibrate=calibrate,


### PR DESCRIPTION
The `xgb_early_test.py` script had an extra `model_type` input, so I removed it.