### PR TITLE
Fixing sort and testing with examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ __pycache__/
 *.py[cod]
 *$py.class
 
+***/catboost_info/***
 # C extensions
 *.so
 _build/

--- a/py_example_scripts/bayesian_test.py
+++ b/py_example_scripts/bayesian_test.py
@@ -5,6 +5,7 @@ from model_tuner.model_tuner_utils import Model
 from imblearn.over_sampling import SMOTE
 from skopt.space import Real, Categorical, Integer
 import model_tuner
+from sklearn.preprocessing import StandardScaler
 
 print()
 print(f"Model Tuner version: {model_tuner.__version__}")
@@ -45,7 +46,7 @@ model = Model(
     model_type="classification",
     calibrate=calibrate,
     estimator=estimator,
-    pipeline_steps=[SimpleImputer()],
+    pipeline_steps=[SimpleImputer(), StandardScaler()],
     kfold=True,
     bayesian=True,
     stratify_y=True,
@@ -56,6 +57,7 @@ model = Model(
     n_jobs=-2,
     random_state=42,
     imbalance_sampler=SMOTE(),
+    sort_preprocess=False,
 )
 
 

--- a/py_example_scripts/lr_smote_test.py
+++ b/py_example_scripts/lr_smote_test.py
@@ -8,9 +8,6 @@ from sklearn.datasets import make_classification
 
 from sklearn.datasets import load_breast_cancer
 from imblearn.over_sampling import SMOTE
-
-from functions import *
-
 from model_tuner.model_tuner_utils import Model
 from model_tuner.bootstrapper import evaluate_bootstrap_metrics
 from model_tuner.pickleObjects import dumpObjects, loadObjects

--- a/py_example_scripts/xgb_multi.py
+++ b/py_example_scripts/xgb_multi.py
@@ -9,6 +9,7 @@ from sklearn.preprocessing import StandardScaler
 from sklearn.compose import ColumnTransformer
 
 from sklearn.datasets import load_iris
+import model_tuner
 
 print()
 print(f"Model Tuner version: {model_tuner.__version__}")

--- a/src/model_tuner/model_tuner_utils.py
+++ b/src/model_tuner/model_tuner_utils.py
@@ -123,6 +123,7 @@ class Model:
         calibration_method="sigmoid",
         custom_scorer=[],
         bayesian=False,
+        sort_preprocess=True,
     ):
 
         # Check if model_type is provided and valid
@@ -140,6 +141,8 @@ class Model:
         self.multi_label = multi_label
         self.calibration_method = calibration_method
         self.imbalance_sampler = imbalance_sampler
+
+        self.preproc_sort = sort_preprocess
 
         if imbalance_sampler:
             from imblearn.pipeline import Pipeline
@@ -308,14 +311,14 @@ class Model:
                     name = f"preprocess_column_transformer_{name}"
                 column_transformer_steps.append((name, transformer))
             elif is_preprocessing_step(transformer):
-                if is_imputer(transformer):
+                if is_imputer(transformer) and self.preproc_sort:
                     # Imputation steps
                     if not name:
                         name = f"preprocess_imputer_step_{len(imputation_steps)}"
                     else:
                         name = f"preprocess_imputer_{name}"
                     imputation_steps.append((name, transformer))
-                elif is_scaler(transformer):
+                elif is_scaler(transformer) and self.preproc_sort:
                     # Scaling steps
                     if not name:
                         name = f"preprocess_scaler_step_{len(scaling_steps)}"
@@ -348,13 +351,16 @@ class Model:
                     name = f"other_{name}"
                 other_steps.append((name, transformer))
 
-        # Assemble the preprocessing steps in the correct order
-        preprocessing_steps = (
-            column_transformer_steps
-            + imputation_steps
-            + scaling_steps
-            + other_preprocessing_steps
-        )
+        # Scale first then impute
+        if self.preproc_sort:
+            preprocessing_steps = (
+                column_transformer_steps
+                + scaling_steps
+                + imputation_steps
+                + other_preprocessing_steps
+            )
+        else:
+            preprocessing_steps = column_transformer_steps + other_preprocessing_steps
 
         # Initialize the main pipeline steps list
         main_pipeline_steps = []


### PR DESCRIPTION
- Made the sorting of preprocessing steps optional: This is for issue #122 
> This is done through the boolean `sort_preprocess` which defaults to True.
- Scaling and then imputation is done if this is set to True.

- Added catboost_info ignore to the .gitignore
- In bayesian test example added an ignore option to test the new sort toggle.
- Also fixed an import error in one of the example py's that was caused by printing the model_tuner version