### PR TITLE
Pipeline sorting now optional

### DIFF
--- a/py_example_scripts/bayesian_test.py
+++ b/py_example_scripts/bayesian_test.py
@@ -5,6 +5,7 @@ from model_tuner.model_tuner_utils import Model
 from imblearn.over_sampling import SMOTE
 from skopt.space import Real, Categorical, Integer
 import model_tuner
+from sklearn.preprocessing import StandardScaler
 
 print()
 print(f"Model Tuner version: {model_tuner.__version__}")
@@ -27,9 +28,9 @@ estimator_name = "xgb"
 xgbearly = False
 
 tuned_parameters = {
-    f"{estimator_name}__max_depth": Integer(2, 1000),
+    f"{estimator_name}__max_depth": Integer(2, 10),
     f"{estimator_name}__learning_rate": Real(1e-5, 1e-1, "log-uniform"),
-    f"{estimator_name}__n_estimators": Integer(3, 1000),
+    f"{estimator_name}__n_estimators": Integer(3, 10),
     f"{estimator_name}__gamma": Real(0, 4, "uniform"),
     "bayes__n_points": 1,
     "bayes__n_iter": 1,
@@ -45,7 +46,7 @@ model = Model(
     model_type="classification",
     calibrate=calibrate,
     estimator=estimator,
-    pipeline_steps=[SimpleImputer()],
+    pipeline_steps=[SimpleImputer(), StandardScaler()],
     kfold=True,
     bayesian=True,
     stratify_y=True,
@@ -53,9 +54,11 @@ model = Model(
     randomized_grid=False,
     feature_selection=False,
     scoring=["roc_auc"],
+    n_splits=2,
     n_jobs=-2,
     random_state=42,
     imbalance_sampler=SMOTE(),
+    sort_preprocess=True,
 )
 
 


### PR DESCRIPTION
- Pipeline sorting now optional through the variable `sort_preprocess`
- Default value is True, so preprocessing steps are sorted scalers first then imputation
- bayesian_test.py rewritten to test this