### PR TITLE
Enhancements and Bug Fixes for Metric Reporting and Threshold Handling

### DIFF
--- a/py_example_scripts/catboost_kfold.py
+++ b/py_example_scripts/catboost_kfold.py
@@ -2,7 +2,7 @@ from catboost import CatBoostClassifier
 from sklearn.impute import SimpleImputer
 from sklearn.datasets import load_breast_cancer
 from sklearn.preprocessing import StandardScaler
-from model_tuner.model_tuner_utils import Model
+from model_tuner.model_tuner_utils import Model, report_model_metrics
 import model_tuner
 
 print()
@@ -54,4 +54,12 @@ y_prob = model.predict_proba(X)
 ### F1 Weighted
 y_pred = model.predict(X)
 
-metrics = model.return_metrics(X, y)
+model.return_metrics(
+    X,
+    y,
+    optimal_threshold=True,
+    print_threshold=True,
+    model_metrics=True,
+)
+
+# report_model_metrics(model, X, y)

--- a/py_example_scripts/catboost_kfold.py
+++ b/py_example_scripts/catboost_kfold.py
@@ -60,7 +60,7 @@ model.return_metrics(
     optimal_threshold=True,
     print_threshold=True,
     model_metrics=True,
-    print_per_fold=False,
+    print_per_fold=True,
 )
 
 # report_model_metrics(model, X, y)

--- a/py_example_scripts/catboost_kfold.py
+++ b/py_example_scripts/catboost_kfold.py
@@ -60,6 +60,7 @@ model.return_metrics(
     optimal_threshold=True,
     print_threshold=True,
     model_metrics=True,
+    print_per_fold=False,
 )
 
 # report_model_metrics(model, X, y)

--- a/py_example_scripts/lr_smote_test.py
+++ b/py_example_scripts/lr_smote_test.py
@@ -124,9 +124,23 @@ X_valid, y_valid = model.get_valid_data(X, y)
 model.fit(X_train, y_train)
 
 print("Validation Metrics")
-model.return_metrics(X_valid, y_valid)
+model.return_metrics(
+    X_valid,
+    y_valid,
+    optimal_threshold=True,
+    print_threshold=True,
+    model_metrics=True,
+    # return_dict=True,
+)
 print("Test Metrics")
-model.return_metrics(X_test, y_test)
+model.return_metrics(
+    X_test,
+    y_test,
+    optimal_threshold=True,
+    print_threshold=True,
+    model_metrics=True,
+    # return_dict=True,
+)
 
 y_prob = model.predict_proba(X_test)
 

--- a/py_example_scripts/lr_smote_test.py
+++ b/py_example_scripts/lr_smote_test.py
@@ -130,7 +130,6 @@ model.return_metrics(
     optimal_threshold=True,
     print_threshold=True,
     model_metrics=True,
-    # return_dict=True,
 )
 print("Test Metrics")
 model.return_metrics(
@@ -139,7 +138,6 @@ model.return_metrics(
     optimal_threshold=True,
     print_threshold=True,
     model_metrics=True,
-    # return_dict=True,
 )
 
 y_prob = model.predict_proba(X_test)

--- a/py_example_scripts/multi_class_test.py
+++ b/py_example_scripts/multi_class_test.py
@@ -64,8 +64,20 @@ X_valid, y_valid = model.get_valid_data(X, y)
 model.fit(X_train, y_train, validation_data=[X_valid, y_valid])
 
 print("Validation Metrics")
-model.return_metrics(X_valid, y_valid)
+model.return_metrics(
+    X_valid,
+    y_valid,
+    optimal_threshold=True,
+    print_threshold=True,
+    model_metrics=True,
+)
 
 y_prob = model.predict_proba(X_test)
 print("Test Metrics")
-model.return_metrics(X_test, y_test)
+model.return_metrics(
+    X_test,
+    y_test,
+    optimal_threshold=True,
+    print_threshold=True,
+    model_metrics=True,
+)

--- a/py_example_scripts/multi_class_test.py
+++ b/py_example_scripts/multi_class_test.py
@@ -54,7 +54,6 @@ model = Model(
     class_labels=["1", "2", "3"],
 )
 
-
 model.grid_search_param_tuning(X, y)
 
 X_train, y_train = model.get_train_data(X, y)

--- a/src/model_tuner/model_tuner_utils.py
+++ b/src/model_tuner/model_tuner_utils.py
@@ -839,6 +839,7 @@ class Model:
         y,
         optimal_threshold=False,
         model_metrics=False,
+        print_threshold=False,
         return_dict=False,
     ):
         """
@@ -942,6 +943,11 @@ class Model:
                 else:
                     if return_dict:
                         return reg_report
+
+            ## Print the threshold if requested
+            if print_threshold:
+                print(f"Optimal threshold used: {threshold}")
+                print()
 
     def predict(self, X, y=None, optimal_threshold=False):
         if self.model_type == "regression":

--- a/src/model_tuner/model_tuner_utils.py
+++ b/src/model_tuner/model_tuner_utils.py
@@ -833,7 +833,14 @@ class Model:
             )
         return bootstrap_metrics
 
-    def return_metrics(self, X, y, optimal_threshold=False, return_dict=False):
+    def return_metrics(
+        self,
+        X,
+        y,
+        optimal_threshold=False,
+        model_metrics=False,
+        return_dict=False,
+    ):
         """
         Evaluate the model on the given dataset and optionally return metrics
         as a dictionary.
@@ -847,6 +854,8 @@ class Model:
         optimal_threshold : bool, optional (default=False)
             Whether to use the optimal threshold for predictions
             (for classification models).
+        model_metrics : bool, optional (default=False)
+            Whether to calculate and print additional model metrics.
         return_dict : bool, optional (default=False)
             Whether to return the metrics as a dictionary.
 
@@ -890,6 +899,8 @@ class Model:
                         threshold = self.threshold[self.scoring[0]]
                     else:
                         threshold = 0.5
+                    if model_metrics:
+                        report_model_metrics(self, X, y, threshold)
                     print("-" * 80)
                 print()
                 self.classification_report = classification_report(

--- a/src/model_tuner/model_tuner_utils.py
+++ b/src/model_tuner/model_tuner_utils.py
@@ -925,9 +925,7 @@ class Model:
                         report_model_metrics(self, X, y, threshold, print_per_fold)
                     print("-" * 80)
                 print()
-                self.classification_report = classification_report(
-                    y, y_pred_valid, output_dict=True
-                )
+                self.classification_report = classification_report(y, y_pred_valid)
                 print(
                     classification_report(
                         y,

--- a/src/model_tuner/model_tuner_utils.py
+++ b/src/model_tuner/model_tuner_utils.py
@@ -892,6 +892,13 @@ class Model:
                 if self.multi_label:
                     conf_mat = multilabel_confusion_matrix(y, y_pred_valid)
                     self._confusion_matrix_print_ML(conf_mat)
+                    if optimal_threshold:
+                        threshold = self.threshold[self.scoring[0]]
+                    else:
+                        threshold = 0.5
+                    if model_metrics:
+                        report_model_metrics(self, X, y, threshold)
+                    print("-" * 80)
                 else:
                     conf_mat = confusion_matrix(y, y_pred_valid)
                     print("Confusion matrix on set provided: ")
@@ -944,10 +951,8 @@ class Model:
                     if return_dict:
                         return reg_report
 
-            ## Print the threshold if requested
-            if print_threshold:
-                print(f"Optimal threshold used: {threshold}")
-                print()
+        if print_threshold:
+            print(f"Optimal threshold used: {threshold}")
 
     def predict(self, X, y=None, optimal_threshold=False):
         if self.model_type == "regression":

--- a/src/model_tuner/model_tuner_utils.py
+++ b/src/model_tuner/model_tuner_utils.py
@@ -888,7 +888,9 @@ class Model:
                     else:
                         threshold = 0.5
                     if model_metrics:
-                        report_model_metrics(self, X, y, threshold, True, print_per_fold)
+                        report_model_metrics(
+                            self, X, y, threshold, True, print_per_fold
+                        )
                     print("-" * 80)
                     print()
 
@@ -1936,8 +1938,10 @@ def report_model_metrics(
     if hasattr(model, "kfold") and model.kfold:  # Handle k-fold logic
         print("\nRunning k-fold model metrics...\n")
         aggregated_metrics = []
-        for fold_idx, (train, test) in enumerate(
-            model.kf.split(X_valid, y_valid), start=1
+        for fold_idx, (train, test) in tqdm(
+            enumerate(model.kf.split(X_valid, y_valid), start=1),
+            total=model.kf.get_n_splits(),
+            desc="Processing Folds",
         ):
             X_train, X_test = X_valid.iloc[train], X_valid.iloc[test]
             y_train, y_test = y_valid.iloc[train], y_valid.iloc[test]
@@ -2013,6 +2017,7 @@ def report_model_metrics(
             print("-" * 80)
 
         return avg_metrics_df
+
     else:
         # Standard single validation logic
         metrics = calculate_metrics(model, X_valid, y_valid, threshold)


### PR DESCRIPTION
## Key Fixes and Updates

### Optimal Threshold Support
- Added the `optimal_threshold=True` logic to `return_metrics`, allowing for custom thresholds to be used dynamically during predictions and evaluations.
- Ensured the threshold is printed at the end of execution if `print_threshold=True`.

### Improved k-fold Metric Reporting
- Enhanced k-fold handling to calculate and display both fold-specific metrics and average metrics across all folds.
- Metrics for each fold are printed in detail, followed by a summary of averaged metrics.

### 🪲Bug Fix: TypeError in k-fold Aggregation
- Resolved the issue where non-numeric columns (`"Metric"`, `"Fold"`) caused aggregation errors during the `mean()` operation.
- Updated logic to only average numeric columns (`"Value"`) using `groupby("Metric")` for proper metric aggregation across folds.

### Preserve Metric Order
- Introduced `metric_order` to ensure that metrics are displayed in a consistent and logical order (e.g., `["Precision/PPV", "Average Precision", "Sensitivity", ...]`).

### Per fold metrics output now optional (Arthur)
- Introduced `tqdm` to track progress of per fold metrics output (Leon)

### Additional Updates
- Removed `output_dict=True` from `self.classification_report` inside `return_metrics()` to properly be able to print classification report if calling it from the model object:

   ```python
  print(model_xgb.classification_report)
   ```

  ```bash
                precision    recall  f1-score   support
  
             0       0.98      0.75      0.85       323
             1       0.55      0.94      0.69       105
  
      accuracy                           0.79       428
     macro avg       0.76      0.84      0.77       428
  weighted avg       0.87      0.79      0.81       428
  ```
