### PR TITLE
Fix: Incorrect Iteration Over `score` String in `calibrateModel`

### DIFF
--- a/py_example_scripts/catboost_kfold_calibrated.py
+++ b/py_example_scripts/catboost_kfold_calibrated.py
@@ -19,6 +19,8 @@ y = bc["target"]
 
 estimator_name = "cat"
 
+calibrate = True
+
 tuned_parameters = {
     f"{estimator_name}__depth": [10],
     f"{estimator_name}__learning_rate": [1e-4],
@@ -34,17 +36,20 @@ model = Model(
     stratify_y=True,
     grid=tuned_parameters,
     randomized_grid=False,
-    n_iter=4,
+    # n_iter=4,
     boost_early=False,
     scoring=["roc_auc"],
     n_jobs=-2,
     random_state=42,
     kfold=True,
+    calibrate=True,
 )
 
 
 model.grid_search_param_tuning(X, y, f1_beta_tune=True)
 
+if model.calibrate:
+    model.calibrateModel(X, y, score="roc_auc")
 
 model.fit(X, y)
 
@@ -60,7 +65,7 @@ model.return_metrics(
     optimal_threshold=True,
     print_threshold=True,
     model_metrics=True,
-    print_per_fold=True,
+    # print_per_fold=True,
 )
 
 print(model.classification_report)

--- a/src/model_tuner/model_tuner_utils.py
+++ b/src/model_tuner/model_tuner_utils.py
@@ -513,10 +513,11 @@ class Model:
                         method=self.calibration_method,
                     ).fit(X, y)
                     test_model = self.estimator
-                    for s in score:
-                        self.conf_mat_class_kfold(
-                            X=X, y=y, test_model=test_model, score=s
-                        )
+
+                    self.conf_mat_class_kfold(
+                        X=X, y=y, test_model=test_model, score=score
+                    )
+
         else:
             if score == None:
                 if self.calibrate:


### PR DESCRIPTION
## Description

When `calibrate=True` and the model is calibrated using the following code:

```python
if model.calibrate:
    model.calibrateModel(X, y, score="roc_auc")
```

The classification report and confusion matrix are printed for each letter in the `score` string instead of being computed for the full `score` parameter (e.g., `"roc_auc"`). This results in incorrect and redundant outputs, as shown in the attached image.

## Root Cause

The issue stems from this block of code:

```python
for s in score:
    self.conf_mat_class_kfold(
        X=X, y=y, test_model=test_model, score=s
    )
```

Here, the `score` parameter (a string) is iterated character by character, causing the function to be executed separately for each letter.

## Proposed Fix

Replace the loop to handle the `score` parameter as a single string instead of iterating over its characters:

```python
self.conf_mat_class_kfold(
    X=X, y=y, test_model=test_model, score=score
)
```
## Testing

- New Script Added: A new script called `catboost_kfold_calibrated.py` was created in the `py_example_scripts` directory to specifically test this behavior.
- Tests were conducted using multiple score parameters, including "roc_auc" and "average_precision", to ensure only a single report is printed per parameter.
- The behavior was also verified with `calibrate=False` to ensure no unintended changes.
