### PR TITLE
Modified `aggregated_y_pred` to `aggregated_y_prob` inside `brier_score_loss`

### DIFF
--- a/src/model_tuner/model_tuner_utils.py
+++ b/src/model_tuner/model_tuner_utils.py
@@ -2700,7 +2700,7 @@ def report_model_metrics(
                 },
                 {
                     "Metric": "Brier Score",
-                    "Value": brier_score_loss(aggregated_y_true, aggregated_y_pred),
+                    "Value": brier_score_loss(aggregated_y_true, aggregated_y_prob),
                 },
             ]
         )


### PR DESCRIPTION
- Updated the second argument of `brier_score_loss` from `aggregated_y_pred` (predictions) to `aggregated_y_prob` (probabilities) as per the [documentation](https://scikit-learn.org/dev/modules/generated/sklearn.metrics.brier_score_loss.html).

  ```python
   "Value": brier_score_loss(aggregated_y_true, aggregated_y_prob),
  ```
