### PR TITLE
Updated `return_dict` logic in `return_metrics`

### DIFF
--- a/src/model_tuner/model_tuner_utils.py
+++ b/src/model_tuner/model_tuner_utils.py
@@ -1112,12 +1112,13 @@ class Model:
                     else:
                         threshold = 0.5
                     if model_metrics:
-                        report_model_metrics(
+                        metrics = report_model_metrics(
                             self, X, y, threshold, True, print_per_fold
                         )
                     print("-" * 80)
                     print()
-
+                    if return_dict:
+                        return metrics.set_index("Metric")["Value"].to_dict()
                 else:
                     self.regression_report_kfold(X, y, self.test_model, score)
 
@@ -1136,10 +1137,12 @@ class Model:
                     else:
                         threshold = 0.5
                     if model_metrics:
-                        report_model_metrics(
+                        metrics = report_model_metrics(
                             self, X, y, threshold, True, print_per_fold
                         )
                     print("-" * 80)
+                    if return_dict:
+                        return metrics.set_index(["Class", "Metric"])["Value"].to_dict()
                 else:
                     conf_mat = confusion_matrix(y, y_pred_valid)
                     self.conf_mat = conf_mat  # store it so we can ext. dict
@@ -1150,10 +1153,12 @@ class Model:
                     else:
                         threshold = 0.5
                     if model_metrics:
-                        report_model_metrics(
+                        metrics = report_model_metrics(
                             self, X, y, threshold, True, print_per_fold
                         )
                     print("-" * 80)
+                    if return_dict:
+                        return metrics.set_index(["Class", "Metric"])["Value"].to_dict()
                 print()
                 self.classification_report = classification_report(
                     y, y_pred_valid, output_dict=True


### PR DESCRIPTION
Previously, `return_metrics` returned `None` when setting `return_dict=True`. This has now been fixed by setting `report_model_metrics` to a new var `metrics` and updating the `return_dict` logic as follows:


```python
  if model_metrics:
      metrics = report_model_metrics(
          self, X, y, threshold, True, print_per_fold
      )
```

```python
if return_dict:
    return metrics.set_index(["Class", "Metric"])["Value"].to_dict()
```
