### PR TITLE
added unittest for catboost_n_iterations, upd. (+1) inside model_tuner…

### DIFF
--- a/src/model_tuner/model_tuner_utils.py
+++ b/src/model_tuner/model_tuner_utils.py
@@ -1519,9 +1519,9 @@ class Model:
                             ].best_iteration
                         except:
                             ### catboost case
-                            params[f"{self.estimator_name}__n_estimators"] = clf[
-                                len(clf) - 1
-                            ].best_iteration_
+                            params[f"{self.estimator_name}__n_estimators"] = (
+                                clf[len(clf) - 1].best_iteration_ + 1
+                            )
 
                         # Update the parameters in the grid
                         self.grid[index] = params


### PR DESCRIPTION
**Fix `grid_search_param_tuning` Issue: Ensure `n_estimators` is Positive**  

**Issue:**  
Fixes a bug where `n_estimators` could be set to `0` in boosting algorithms like `CatBoost` when `best_iteration_` is directly assigned. This causes `CatBoost` to throw an error in rare cases of early stopping with `best_iteration=0`.  

**Fix:**  
Added `+1` to `best_iteration_` for CatBoost to ensure `n_estimators` is always positive.  

```python
try:
    ### XGBoost case
    params[f"{self.estimator_name}__n_estimators"] = clf[len(clf) - 1].best_iteration
except:
    ### CatBoost case
    params[f"{self.estimator_name}__n_estimators"] = clf[len(clf) - 1].best_iteration_ + 1
```

- Added new unit test inisde `test_model.py` for this scenario: `test_catboost_earlystop_best_iteration()`

- Feel free to remove commented out custom assertion (lines 1050-1052) in `test_model.py`:

  ```python
      # assert (
      #     model.best_params_per_score["roc_auc"]["params"]["cat__n_estimators"] == 1
      # ), "Number of n_estimator should be 1"
  
  ```
