### PR TITLE
Xgboost n estimators fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ If you use `model_tuner` in your research or projects, please consider citing it
   month        = jul,
   year         = 2024,
   publisher    = {Zenodo},
-  version      = {0.0.26b},
+  version      = {0.0.27b},
   doi          = {10.5281/zenodo.12727322},
   url          = {https://doi.org/10.5281/zenodo.12727322}
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "model_tuner"
-version = "0.0.26b"
+version = "0.0."
 description = "A Python library for tuning machine learning models."
 readme = { file = "README.md", content-type = "text/markdown" }
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "model_tuner"
-version = "0.0."
+version = "0.0.27b"
 description = "A Python library for tuning machine learning models."
 readme = { file = "README.md", content-type = "text/markdown" }
 authors = [

--- a/src/model_tuner/__init__.py
+++ b/src/model_tuner/__init__.py
@@ -19,7 +19,7 @@ PyPI: https://pypi.org/project/model-tuner/
 Documentation: https://uclamii.github.io/model_tuner/
 
 
-Version: 0.0.26b
+Version: 0.0.27b
 
 """
 
@@ -27,7 +27,7 @@ Version: 0.0.26b
 __doc__ = detailed_doc
 
 
-__version__ = "0.0.26b"
+__version__ = "0.0.27b"
 __author__ = "Arthur Funnell, Leonid Shpaner, Panayiotis Petousis"
 __email__ = "lshpaner@ucla.edu; alafunnell@gmail.com; pp89@ucla.edu"
 

--- a/src/model_tuner/model_tuner_utils.py
+++ b/src/model_tuner/model_tuner_utils.py
@@ -1480,9 +1480,9 @@ class Model:
                         ### setting the current item in the grid to this number
                         try:
                             ### XGBoost case
-                            params[f"{self.estimator_name}__n_estimators"] = clf[
-                                len(clf) - 1
-                            ].best_iteration
+                            params[f"{self.estimator_name}__n_estimators"] = (
+                                clf[len(clf) - 1].best_iteration + 1
+                            )
                         except:
                             ### catboost case
                             params[f"{self.estimator_name}__n_estimators"] = (


### PR DESCRIPTION
Simple patch that updates xgboost to match catboost behaviour when n_estimators is specified. We add 1 to the n_estimators variable as xgboost enumerates from 0. 