### PR TITLE
Google colab compatibility - pandas version

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ If you use `model_tuner` in your research or projects, please consider citing it
   month        = jul,
   year         = 2024,
   publisher    = {Zenodo},
-  version      = {0.0.26b},
+  version      = {0.0.27b},
   doi          = {10.5281/zenodo.12727322},
   url          = {https://doi.org/10.5281/zenodo.12727322}
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "model_tuner"
-version = "0.0.26b"
+version = "0.0.27b"
 description = "A Python library for tuning machine learning models."
 readme = { file = "README.md", content-type = "text/markdown" }
 authors = [
@@ -37,7 +37,7 @@ dependencies = [
     "setuptools==75.1.0; python_version >= '3.11'",
     "wheel==0.44.0; python_version >= '3.11'",
     "numpy>=1.19.5, <2.0.0; python_version >= '3.11'",
-    "pandas>=1.3.5, <2.2.2; python_version >= '3.11'",
+    "pandas>=1.3.5, <2.2.3; python_version >= '3.11'",
     "scikit-learn==1.5.1; python_version >= '3.11'",
     "scipy==1.14.0; python_version >= '3.11'",
     "imbalanced-learn==0.12.4; python_version >= '3.11'",

--- a/src/model_tuner/__init__.py
+++ b/src/model_tuner/__init__.py
@@ -19,7 +19,7 @@ PyPI: https://pypi.org/project/model-tuner/
 Documentation: https://uclamii.github.io/model_tuner/
 
 
-Version: 0.0.26b
+Version: 0.0.27b
 
 """
 
@@ -27,7 +27,7 @@ Version: 0.0.26b
 __doc__ = detailed_doc
 
 
-__version__ = "0.0.26b"
+__version__ = "0.0.27b"
 __author__ = "Arthur Funnell, Leonid Shpaner, Panayiotis Petousis"
 __email__ = "lshpaner@ucla.edu; alafunnell@gmail.com; pp89@ucla.edu"
 


### PR DESCRIPTION
- Updated to use pandas 2.2.2 if possible, this will make it more compatible with google colab. 