### PR TITLE
upd. CalibratedClassifier to use validation set

### DIFF
--- a/py_example_scripts/early_cat_col_trans.py
+++ b/py_example_scripts/early_cat_col_trans.py
@@ -1,0 +1,113 @@
+### Defining columns to be scaled and columns to be onehotencoded
+from sklearn.preprocessing import OneHotEncoder, OrdinalEncoder
+from sklearn.compose import ColumnTransformer
+from sklearn.preprocessing import StandardScaler
+from catboost import CatBoostClassifier
+import seaborn as sns
+from sklearn.impute import SimpleImputer
+from model_tuner import Model
+from sklearn.pipeline import Pipeline
+import model_tuner
+
+print()
+print(f"Model Tuner version: {model_tuner.__version__}")
+print(f"Model Tuner authors: {model_tuner.__author__}")
+print()
+
+titanic = sns.load_dataset("titanic")
+titanic.head()
+X = titanic[[col for col in titanic.columns if col != "survived"]]
+### Removing repeated data
+X = X.drop(columns=["alive", "class", "embarked"])
+y = titanic["survived"]
+
+ohcols = ["embark_town", "who", "sex", "adult_male"]
+ordcols = ["deck"]
+scalercols = ["parch", "fare", "age", "pclass"]
+
+numerical_transformer = Pipeline(
+    steps=[
+        ("scaler", StandardScaler()),
+        ("imputer", SimpleImputer(strategy="mean")),
+    ]
+)
+
+categorical_transformer = Pipeline(
+    steps=[
+        ("imputer", SimpleImputer(strategy="constant", fill_value="missing")),
+        ("encoder", OneHotEncoder(handle_unknown="ignore")),
+    ]
+)
+
+ordinal_transformer = Pipeline(
+    steps=[
+        ("imputer", SimpleImputer(strategy="constant", fill_value="missing")),
+        ("ord_encoder", OrdinalEncoder()),
+    ]
+)
+
+# Create the ColumnTransformer with passthrough
+preprocessor = ColumnTransformer(
+    transformers=[
+        ("num", numerical_transformer, scalercols),
+        ("cat", categorical_transformer, ohcols),
+        ("ord", ordinal_transformer, ordcols),
+    ],
+    remainder="passthrough",
+)
+
+# CatBoost definition
+catboost_name = "catboost"
+catboost = CatBoostClassifier(verbose=0)  # verbose=0 to suppress training output
+tuned_parameters_catboost = {
+    f"{catboost_name}__depth": [3, 5, 10],
+    f"{catboost_name}__early_stopping_rounds": [10],
+    f"{catboost_name}__learning_rate": [0.01, 0.03, 0.1],
+}
+catboost_definition = {
+    "clc": catboost,
+    "estimator_name": catboost_name,
+    "tuned_parameters": tuned_parameters_catboost,
+    "randomized_grid": True,
+    "n_iter": 20,
+    "early": True,
+}
+
+kfold = False
+
+# Initialize titanic_model
+titanic_model_catboost = Model(
+    name="CatBoost_Titanic",
+    estimator_name=catboost_definition["estimator_name"],
+    model_type="classification",
+    calibrate=True,
+    estimator=catboost_definition["clc"],
+    kfold=kfold,
+    pipeline_steps=[("Preprocessor", preprocessor)],
+    stratify_y=True,
+    grid=catboost_definition["tuned_parameters"],
+    randomized_grid=catboost_definition["randomized_grid"],
+    n_iter=catboost_definition["n_iter"],
+    scoring=["roc_auc"],
+    random_state=42,
+    boost_early=True,
+    n_jobs=-1,
+)
+
+# Perform grid search
+titanic_model_catboost.grid_search_param_tuning(X, y, f1_beta_tune=True)
+
+# Get the training and validation data
+X_train, y_train = titanic_model_catboost.get_train_data(X, y)
+X_valid, y_valid = titanic_model_catboost.get_valid_data(X, y)
+X_test, y_test = titanic_model_catboost.get_test_data(X, y)
+
+# Fit the model (assuming best params are applied internally)
+titanic_model_catboost.fit(X_train, y_train, validation_data=[X_valid, y_valid])
+
+# Predict probabilities
+prob_uncalibrated = titanic_model_catboost.predict_proba(X_test)[:, 1]
+
+# Calibrate if needed
+if titanic_model_catboost.calibrate:
+    titanic_model_catboost.calibrateModel(X, y)

--- a/py_example_scripts/rf_calibrated.py
+++ b/py_example_scripts/rf_calibrated.py
@@ -1,0 +1,82 @@
+from sklearn.datasets import load_breast_cancer
+from sklearn.preprocessing import StandardScaler
+from sklearn.impute import SimpleImputer
+from model_tuner.model_tuner_utils import Model
+import model_tuner
+from sklearn.ensemble import RandomForestClassifier
+
+print()
+print(f"Model Tuner version: {model_tuner.__version__}")
+print(f"Model Tuner authors: {model_tuner.__author__}")
+print()
+
+# Load dataset
+bc = load_breast_cancer(as_frame=True)["frame"]
+bc_cols = [cols for cols in bc.columns if "target" not in cols]
+X = bc[bc_cols]
+y = bc["target"]
+
+rstate = 42
+
+print(X.shape)
+
+# Define Random Forest classifier
+estimator = RandomForestClassifier(
+    class_weight="balanced", random_state=rstate, n_jobs=-1  # Handle class imbalance
+)
+
+estimator_name = "rf"
+
+tuned_parameters = {
+    f"{estimator_name}__n_estimators": [100, 200],  # Number of trees in the forest
+    f"{estimator_name}__max_depth": [5, 10, None],  # Control tree depth
+    f"{estimator_name}__min_samples_split": [2, 5],  # Minimum samples required to split
+}
+
+kfold = False
+calibrate = True  # Allow calibration for probability outputs
+
+pipeline = [
+    ("StandardScalar", StandardScaler()),
+    ("Preprocessor", SimpleImputer()),
+]
+
+# Define model pipeline
+model = Model(
+    name="Random Forest Classifier",
+    estimator_name=estimator_name,
+    calibrate=calibrate,
+    model_type="classification",
+    estimator=estimator,
+    pipeline_steps=pipeline,
+    kfold=kfold,
+    stratify_y=True,
+    grid=tuned_parameters,
+    randomized_grid=False,
+    n_iter=4,
+    boost_early=False,  # Not applicable for Random Forest
+    scoring=["roc_auc"],
+    n_jobs=-2,
+    random_state=rstate,
+)
+
+# Perform grid search
+model.grid_search_param_tuning(X, y, f1_beta_tune=True)
+
+# Fit model
+model.fit(X, y)
+
+if model.calibrate:
+    model.calibrateModel(
+        X,
+        y,
+        score="roc_auc",
+    )
+
+# Evaluate metrics
+print("Validation Metrics")
+model.return_metrics(X, y, print_threshold=True, model_metrics=True)
+
+# Predict probabilities and classes
+y_prob = model.predict_proba(X)
+y_pred = model.predict(X, optimal_threshold=True)

--- a/src/model_tuner/model_tuner_utils.py
+++ b/src/model_tuner/model_tuner_utils.py
@@ -588,7 +588,7 @@ class Model:
                         self.estimator,
                         cv="prefit",
                         method=self.calibration_method,
-                    ).fit(X_test, y_test)
+                    ).fit(X_valid, y_valid)
                 else:
                     pass
             else:
@@ -642,7 +642,7 @@ class Model:
                         self.estimator,
                         cv="prefit",
                         method=self.calibration_method,
-                    ).fit(X_test, y_test)
+                    ).fit(X_valid, y_valid)
                     test_model = self.estimator
                     print(
                         f"{score} after calibration:",

--- a/src/model_tuner/model_tuner_utils.py
+++ b/src/model_tuner/model_tuner_utils.py
@@ -540,10 +540,6 @@ class Model:
                     ).fit(X, y)
                     test_model = self.estimator
 
-                    # self.conf_mat_class_kfold(
-                    #     X=X, y=y, test_model=test_model, score=score
-                    # )
-
         else:
             if score == None:
                 if self.calibrate:


### PR DESCRIPTION
- Updated the `CalibratedClassifierCV` to fit on the validation set in two cases where `cv=prefit` is specified within the same block.
- Removed old (deprecated) commented out code in the `calibrateModel` method
- Added `rf`_calibrated_test.py` and `early_cat_col_trans.py` 
- All unit tests pass; none additional required