### PR TITLE
Update docstring for `stratify_y` in `train_val_test_split`

### DIFF
--- a/src/model_tuner/model_tuner_utils.py
+++ b/src/model_tuner/model_tuner_utils.py
@@ -2100,8 +2100,9 @@ def train_val_test_split(
         The feature matrix to split.
     y : pandas.Series or array-like
         The target vector corresponding to `X`.
-    stratify_y : pandas.Series or None, optional
-        Specifies whether to stratify based on the target variable.
+    stratify_y : bool, optional
+        If True, stratifies based on the target variable (`y`).
+        If None or False, no stratification is applied.
         Default is None.
     train_size : float, optional
         Proportion of the data to allocate to the training set.


### PR DESCRIPTION
This PR updates the docstring for the `stratify_y` parameter in the `train_val_test_split` function. The update clarifies that `stratify_y` should be a boolean (`True` or `None`), removing the previous reference to `pandas.Series`, which could cause errors.

#### Changes Made
**Updated docstring for `stratify_y`:**
```python
stratify_y : bool, optional
    If True, stratifies based on the target variable (`y`).
    If None or False, no stratification is applied.
    Default is None.
```
- No functional code changes were made; only the documentation was updated.
- Existing functionality remains unchanged.

