### PR TITLE
Upd. versioning for 3.7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.0.28b"
 description = "A Python library for training and tuning machine learning models."
 readme = { file = "README.md", content-type = "text/markdown" }
 authors = [
-    { name = "UCLA CTSI ML Team: Leonid Shpaner, Arthur Funnell, Panayiotis Petousis", email = "pp89@ucla.edu" }
+    { name = "UCLA CTSI ML Team: Arthur Funnell, Leonid Shpaner, Panayiotis Petousis", email = "pp89@ucla.edu" }
 ]
 requires-python = ">=3.7"
 dependencies = [
@@ -16,13 +16,13 @@ dependencies = [
     "tqdm==4.66.4",
     "catboost==1.2.7",
 
-    "numpy==1.21.4; python_version == '3.7'",
-    "pandas==1.1.5; python_version == '3.7'",
-    "scikit-learn==0.23.2; python_version == '3.7'",
-    "scipy==1.4.1; python_version == '3.7'",
-    "imbalanced-learn==0.7.0; python_version == '3.7'",
-    "scikit-optimize==0.8.1; python_version == '3.7'",
-    "xgboost==1.6.2; python_version == '3.7'",
+    "numpy>=1.21.4, <1.23.0; python_version >= '3.7' and python_version < '3.8'",
+    "pandas>=1.1.5, <1.3.5; python_version >= '3.7' and python_version < '3.8'",
+    "scikit-learn>=0.23.2, <1.0.2; python_version >= '3.7' and python_version < '3.8'",
+    "scipy>=1.4.1, <1.11; python_version >= '3.7' and python_version < '3.8'",
+    "imbalanced-learn>=0.7.0, <0.8.0; python_version >= '3.7' and python_version < '3.8'",
+    "scikit-optimize>=0.8.1, <0.10.2 python_version >= '3.7' and python_version < '3.8'",
+    "xgboost>=1.6.2, <2.1.2; python_version >= '3.7' and python_version < '3.8'",
 
     "setuptools==75.1.0; python_version >= '3.8' and python_version < '3.11'",
     "wheel==0.44.0; python_version >= '3.8' and python_version < '3.11'",


### PR DESCRIPTION
## Refined Python 3.7 Dependency Constraints

- Added upper bounds for all Python 3.7 dependencies (`<3.8`)
- Ensures compatibility by explicitly scoping packages to Python 3.7.x