### PR TITLE
Use model’s optimal threshold when predicting on bootstrap resamples

### DIFF
--- a/src/model_tuner/bootstrapper.py
+++ b/src/model_tuner/bootstrapper.py
@@ -184,7 +184,7 @@ def evaluate_bootstrap_metrics(
             y_pred_prob_resample = y_pred_prob.iloc[resampled_indicies]
 
             if model_type != "regression":
-                y_pred_resample = (y_pred_prob_resample >= threshold).astype(int)
+                y_pred_resample = (y_pred_prob_resample > threshold).astype(int)
             else:
                 y_pred_resample = y_pred_prob_resample
         else:
@@ -198,7 +198,7 @@ def evaluate_bootstrap_metrics(
                 y_pred_prob_resample = model.predict_proba(X_resample)[:, 1]
             else:
                 y_pred_prob_resample = None
-            y_pred_resample = model.predict(X_resample)
+            y_pred_resample = model.predict(X_resample, optimal_threshold=True)
 
         # Calculate and store metric scores
         for metric in metrics:

--- a/unittests/test_bootstrapper.py
+++ b/unittests/test_bootstrapper.py
@@ -1,6 +1,7 @@
 import pytest
 import numpy as np
 import pandas as pd
+from model_tuner import Model
 from sklearn.datasets import make_classification
 from sklearn.ensemble import RandomForestClassifier
 from src.model_tuner.bootstrapper import (
@@ -90,9 +91,21 @@ def test_evaluate_bootstrap_metrics() -> None:
     """Test the evaluate_bootstrap_metrics function with various configurations."""
     # Generate data
     X, y = generate_classification_data(n_samples=500)
-    model = RandomForestClassifier(random_state=42)
-    model.fit(X, y)
 
+    X_single = X.iloc[:, [0]]
+
+    model = Model(
+        name="compare_test",
+        estimator_name="rf",
+        estimator=RandomForestClassifier(),
+        model_type="classification",
+        grid={},  # Not doing hyperparam tuning for simplicity
+        scoring=["accuracy"],  # Simplify
+        class_labels=["0", "1"],  # Let’s define these for the classification report
+    )
+
+    model.grid_search_param_tuning(X_single, y)
+    model.fit(X, y)
     # Test without y_pred_prob
     results = evaluate_bootstrap_metrics(
         model=model,


### PR DESCRIPTION
In the evaluate_bootstrap_metrics function, switched the bootstrap branch from:

```python
y_pred_resample = model.predict(X_resample)
```


```python
y_pred_resample = model.predict(X_resample, optimal_threshold=True)
```

This ensures that during each resample we apply the model’s own optimal threshold (rather than a fixed 0.5) when turning probabilities into class labels.

- updated corresponding pytest