### PR TITLE
add youdens j

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -155,4 +155,5 @@ Images/
 
 */.doctrees/
 
-docs/.doctrees/
+docs/.doctrees/images/
+images/

--- a/py_example_scripts/threshold_testing_rf_youden.py
+++ b/py_example_scripts/threshold_testing_rf_youden.py
@@ -1,0 +1,267 @@
+"""
+Threshold selection comparison on the ACTG 175 AIDS clinical trials cohort.
+
+Compares three ways of choosing an operating point for a calibrated
+RandomForest:
+
+    1. find_optimal_threshold_beta(target_metric="precision", ...)
+    2. find_optimal_threshold_beta(target_metric="recall", ...)
+    3. find_optimal_threshold_youden(...)          <-- added
+
+The first two require the caller to guess a `target_score` up front and then
+re-run to discover what operating point that produced. Youden's J derives the
+cut-point from the ROC curve directly: no target score, no beta.
+
+Reference:
+    Youden WJ. Index for rating diagnostic tests. Cancer. 1950;3(1):32-35.
+"""
+
+import pandas as pd
+import numpy as np
+
+from sklearn.ensemble import RandomForestClassifier
+from sklearn.calibration import calibration_curve
+from sklearn.metrics import (
+    confusion_matrix,
+    roc_auc_score,
+    average_precision_score,
+)
+import matplotlib.pyplot as plt
+
+import model_tuner  ## import model_tuner to show version info.
+from model_tuner import Model  ## Model class from model_tuner lib.
+from model_tuner.threshold_optimization import (
+    find_optimal_threshold_beta,
+    find_optimal_threshold_youden,
+)
+
+from ucimlrepo import fetch_ucirepo
+
+print(f"model_tuner version: {model_tuner.__version__}")
+
+################################################################################
+## Data
+################################################################################
+
+aids_clinical_trials_group_study_175 = fetch_ucirepo(id=890)
+
+X = aids_clinical_trials_group_study_175.data.features
+y = aids_clinical_trials_group_study_175.data.targets
+
+if isinstance(y, pd.DataFrame):
+    y = y.squeeze()
+
+## Drop zero-variance columns
+zero_variance_columns = X.columns[X.var() == 0]
+if not zero_variance_columns.empty:
+    X = X.drop(columns=zero_variance_columns)
+
+print(f"n = {len(y)}, events = {int(y.sum())}, prevalence = {y.mean():.4f}")
+
+################################################################################
+## Model
+################################################################################
+
+rf = RandomForestClassifier(class_weight="balanced", random_state=42)
+
+estimator_name = "rf"
+tuned_parameters = [
+    {
+        estimator_name + "__n_estimators": [100],
+        estimator_name + "__max_depth": [None, 10],
+    }
+]
+
+kfold = False
+calibrate = True
+
+model = Model(
+    name="Random Forest",
+    estimator_name=estimator_name,
+    model_type="classification",
+    calibrate=calibrate,
+    estimator=rf,
+    kfold=kfold,
+    stratify_y=True,
+    stratify_cols=["gender"],
+    grid=tuned_parameters,
+    randomized_grid=True,
+    n_iter=40,
+    scoring=["roc_auc"],
+    n_splits=10,
+    n_jobs=-2,
+    random_state=42,
+)
+
+model.grid_search_param_tuning(X, y, f1_beta_tune=True)
+
+X_train, y_train = model.get_train_data(X, y)
+X_test, y_test = model.get_test_data(X, y)
+X_valid, y_valid = model.get_valid_data(X, y)
+
+model.fit(X_train, y_train, validation_data=[X_valid, y_valid])
+
+## Calibration curve before calibration, for reference
+y_prob_uncalibrated = model.predict_proba(X_test)[:, 1]
+prob_true_uncalibrated, prob_pred_uncalibrated = calibration_curve(
+    y_test,
+    y_prob_uncalibrated,
+    n_bins=10,
+)
+
+if model.calibrate:
+    model.calibrateModel(X, y, score="roc_auc")
+
+################################################################################
+## Threshold selection
+################################################################################
+
+## Thresholds are chosen on the VALIDATION set and reported on the TEST set.
+y_prob_valid = model.predict_proba(X_valid)[:, 1]
+y_prob_test = model.predict_proba(X_test)[:, 1]
+
+prevalence = float(y_valid.mean())
+results = {}
+
+
+def evaluate(label, threshold):
+    """Confusion matrix and rates on the test set at a given cut-point."""
+    y_hat = (y_prob_test > threshold).astype(int)
+    tn, fp, fn, tp = confusion_matrix(y_test, y_hat, labels=[0, 1]).ravel()
+    results[label] = {
+        "threshold": round(float(threshold), 3),
+        "TP": tp,
+        "FN": fn,
+        "FP": fp,
+        "TN": tn,
+        "sensitivity": tp / (tp + fn) if (tp + fn) else np.nan,
+        "specificity": tn / (tn + fp) if (tn + fp) else np.nan,
+        "precision": tp / (tp + fp) if (tp + fp) else np.nan,
+        "youden_J": (
+            (tp / (tp + fn) + tn / (tn + fp) - 1) if (tp + fn) and (tn + fp) else np.nan
+        ),
+    }
+    return results[label]
+
+
+## ---------------------------------------------------------------------------
+## 1. Target precision = 0.5
+## ---------------------------------------------------------------------------
+
+threshold_precision, beta_precision = find_optimal_threshold_beta(
+    y_valid,
+    y_prob_valid,
+    target_metric="precision",
+    target_score=0.5,
+    beta_value_range=np.linspace(0.01, 4, 40),
+    threshold_value_range=[0.2, 1],
+    delta=0.05,
+)
+
+model.threshold["roc_auc"] = threshold_precision
+metrics_precision = model.return_metrics(
+    X_valid, y_valid, optimal_threshold=True, model_metrics=True
+)
+evaluate("precision target 0.50", threshold_precision)
+
+## ---------------------------------------------------------------------------
+## 2. Target recall = 0.8
+## ---------------------------------------------------------------------------
+
+threshold_recall, beta_recall = find_optimal_threshold_beta(
+    y_valid,
+    y_prob_valid,
+    target_metric="recall",
+    target_score=0.8,
+    beta_value_range=np.linspace(0.01, 4, 40),
+    threshold_value_range=[0.3, 0.7],
+    delta=0.08,
+)
+
+model.threshold["roc_auc"] = threshold_recall
+metrics_recall = model.return_metrics(
+    X_valid, y_valid, optimal_threshold=True, model_metrics=True
+)
+evaluate("recall target 0.80", threshold_recall)
+
+## ---------------------------------------------------------------------------
+## 3. Youden's J
+## ---------------------------------------------------------------------------
+## No target score and no beta. The cut-point maximizing sensitivity +
+## specificity - 1 is read straight off the ROC curve, so nothing has to be
+## guessed in advance and re-run.
+
+threshold_youden, beta_youden = find_optimal_threshold_youden(
+    y_valid,
+    y_prob_valid,
+    threshold_value_range=np.arange(0, 1, 0.01),
+)
+
+model.threshold["roc_auc"] = threshold_youden
+metrics_youden = model.return_metrics(
+    X_valid, y_valid, optimal_threshold=True, model_metrics=True
+)
+evaluate("Youden's J", threshold_youden)
+
+################################################################################
+## Comparison
+################################################################################
+
+comparison = pd.DataFrame(results).T
+comparison.index.name = "criterion"
+
+print("\n" + "=" * 78)
+print("Threshold selected on validation, evaluated on test")
+print("=" * 78)
+print(f"validation prevalence: {prevalence:.4f}")
+print(f"test AUC             : {roc_auc_score(y_test, y_prob_test):.4f}")
+print(f"test avg precision   : {average_precision_score(y_test, y_prob_test):.4f}")
+print()
+print(comparison.to_string())
+print()
+print(f"beta (precision target): {beta_precision}")
+print(f"beta (recall target)   : {beta_recall}")
+print(f"beta (Youden)          : {beta_youden}   <- none required")
+
+################################################################################
+## Threshold sweep
+################################################################################
+## Plotting the metrics against threshold shows where each criterion landed,
+## and whether it sits in a stable region of the curve or in the ragged tail
+## where one or two patients move the numbers around.
+
+grid = np.arange(0.01, 1.0, 0.01)
+sens, spec, prec = [], [], []
+for t in grid:
+    y_hat = (y_prob_test > t).astype(int)
+    tn, fp, fn, tp = confusion_matrix(y_test, y_hat, labels=[0, 1]).ravel()
+    sens.append(tp / (tp + fn) if (tp + fn) else np.nan)
+    spec.append(tn / (tn + fp) if (tn + fp) else np.nan)
+    prec.append(tp / (tp + fp) if (tp + fp) else np.nan)
+
+plt.figure(figsize=(10, 6))
+plt.plot(grid, sens, label="Sensitivity")
+plt.plot(grid, spec, label="Specificity")
+plt.plot(grid, prec, label="Precision")
+
+for label, style in [
+    ("precision target 0.50", ":"),
+    ("recall target 0.80", "-."),
+    ("Youden's J", "--"),
+]:
+    plt.axvline(
+        results[label]["threshold"],
+        linestyle=style,
+        color="black",
+        alpha=0.7,
+        label=f"{label} ({results[label]['threshold']:.2f})",
+    )
+
+plt.axvline(prevalence, color="grey", alpha=0.4, label=f"prevalence ({prevalence:.2f})")
+plt.xlabel("Threshold")
+plt.ylabel("Metric")
+plt.title("Operating point selected by each criterion")
+plt.legend(loc="best", fontsize=8)
+plt.grid(alpha=0.3)
+plt.tight_layout()
+plt.show()

--- a/py_example_scripts/threshold_testing_rf_youden.py
+++ b/py_example_scripts/threshold_testing_rf_youden.py
@@ -1,57 +1,59 @@
 """
-Threshold selection comparison on the ACTG 175 AIDS clinical trials cohort.
+F-beta sweep vs Youden's J for threshold selection.
 
-Compares three ways of choosing an operating point for a calibrated
-RandomForest:
+model_tuner already selects a threshold with no target score required:
+`grid_search_param_tuning(f1_beta_tune=True)` and
+`calibrateModel(f1_beta_tune=True)` both sweep betas and thresholds and set
+`model.threshold[score]` internally.
 
-    1. find_optimal_threshold_beta(target_metric="precision", ...)
-    2. find_optimal_threshold_beta(target_metric="recall", ...)
-    3. find_optimal_threshold_youden(...)          <-- added
+The question this script asks is not whether that works, but whether F-beta is
+the right criterion family. F-beta is the harmonic mean of precision and
+recall, so true negatives never enter the calculation. Youden's J is
+sensitivity + specificity - 1, so specificity enters explicitly.
 
-The first two require the caller to guess a `target_score` up front and then
-re-run to discover what operating point that produced. Youden's J derives the
-cut-point from the ROC curve directly: no target score, no beta.
+Run on the ACTG 175 AIDS clinical trials cohort.
 
 Reference:
     Youden WJ. Index for rating diagnostic tests. Cancer. 1950;3(1):32-35.
 """
+from pathlib import Path
 
-import pandas as pd
 import numpy as np
-
-from sklearn.ensemble import RandomForestClassifier
-from sklearn.calibration import calibration_curve
-from sklearn.metrics import (
-    confusion_matrix,
-    roc_auc_score,
-    average_precision_score,
-)
+import pandas as pd
 import matplotlib.pyplot as plt
 
-import model_tuner  ## import model_tuner to show version info.
-from model_tuner import Model  ## Model class from model_tuner lib.
-from model_tuner.threshold_optimization import (
-    find_optimal_threshold_beta,
-    find_optimal_threshold_youden,
+from sklearn.ensemble import RandomForestClassifier
+from sklearn.metrics import (
+    average_precision_score,
+    confusion_matrix,
+    roc_auc_score,
 )
+
+import model_tuner
+from model_tuner import Model
+from model_tuner.threshold_optimization import find_optimal_threshold_youden
 
 from ucimlrepo import fetch_ucirepo
 
 print(f"model_tuner version: {model_tuner.__version__}")
 
+IMAGES_DIR = Path("./images")
+IMAGES_DIR.mkdir(parents=True, exist_ok=True)
+
+SCORE = "roc_auc"
+
 ################################################################################
 ## Data
 ################################################################################
 
-aids_clinical_trials_group_study_175 = fetch_ucirepo(id=890)
+aids = fetch_ucirepo(id=890)
 
-X = aids_clinical_trials_group_study_175.data.features
-y = aids_clinical_trials_group_study_175.data.targets
+X = aids.data.features
+y = aids.data.targets
 
 if isinstance(y, pd.DataFrame):
     y = y.squeeze()
 
-## Drop zero-variance columns
 zero_variance_columns = X.columns[X.var() == 0]
 if not zero_variance_columns.empty:
     X = X.drop(columns=zero_variance_columns)
@@ -72,53 +74,64 @@ tuned_parameters = [
     }
 ]
 
-kfold = False
-calibrate = True
-
 model = Model(
     name="Random Forest",
     estimator_name=estimator_name,
     model_type="classification",
-    calibrate=calibrate,
+    calibrate=True,
     estimator=rf,
-    kfold=kfold,
+    kfold=False,
     stratify_y=True,
     stratify_cols=["gender"],
     grid=tuned_parameters,
     randomized_grid=True,
     n_iter=40,
-    scoring=["roc_auc"],
+    scoring=[SCORE],
     n_splits=10,
     n_jobs=-2,
     random_state=42,
 )
 
+## f1_beta_tune=True sweeps betas and thresholds. No target score is passed.
 model.grid_search_param_tuning(X, y, f1_beta_tune=True)
 
 X_train, y_train = model.get_train_data(X, y)
-X_test, y_test = model.get_test_data(X, y)
 X_valid, y_valid = model.get_valid_data(X, y)
+X_test, y_test = model.get_test_data(X, y)
 
 model.fit(X_train, y_train, validation_data=[X_valid, y_valid])
 
-## Calibration curve before calibration, for reference
-y_prob_uncalibrated = model.predict_proba(X_test)[:, 1]
-prob_true_uncalibrated, prob_pred_uncalibrated = calibration_curve(
-    y_test,
-    y_prob_uncalibrated,
-    n_bins=10,
-)
-
-if model.calibrate:
-    model.calibrateModel(X, y, score="roc_auc")
+print(f"\nThreshold after grid search (uncalibrated): {model.threshold[SCORE]:.3f}")
 
 ################################################################################
-## Threshold selection
+## Calibrate, retuning the threshold afterwards
+################################################################################
+## Calibration refits the estimator and shifts the probability distribution,
+## so a threshold chosen beforehand no longer matches the final model.
+## f1_beta_tune=True here retunes on the calibrated probabilities.
+
+model.calibrateModel(X, y, score=SCORE, f1_beta_tune=True)
+
+threshold_fbeta = float(model.threshold[SCORE])
+print(f"Threshold after calibration (F-beta sweep) : {threshold_fbeta:.3f}")
+
+################################################################################
+## Youden's J on the same calibrated model
 ################################################################################
 
-## Thresholds are chosen on the VALIDATION set and reported on the TEST set.
 y_prob_valid = model.predict_proba(X_valid)[:, 1]
 y_prob_test = model.predict_proba(X_test)[:, 1]
+
+threshold_youden, beta_youden = find_optimal_threshold_youden(
+    y_valid,
+    y_prob_valid,
+    threshold_value_range=np.arange(0, 1, 0.01),
+)
+print(f"Threshold from Youden's J                  : {threshold_youden:.3f}")
+
+################################################################################
+## Evaluate both cut-points on the test set
+################################################################################
 
 prevalence = float(y_valid.mean())
 results = {}
@@ -128,84 +141,33 @@ def evaluate(label, threshold):
     """Confusion matrix and rates on the test set at a given cut-point."""
     y_hat = (y_prob_test > threshold).astype(int)
     tn, fp, fn, tp = confusion_matrix(y_test, y_hat, labels=[0, 1]).ravel()
+
+    sensitivity = tp / (tp + fn) if (tp + fn) else np.nan
+    specificity = tn / (tn + fp) if (tn + fp) else np.nan
+    precision = tp / (tp + fp) if (tp + fp) else np.nan
+    f1 = (
+        2 * precision * sensitivity / (precision + sensitivity)
+        if precision and sensitivity
+        else np.nan
+    )
+
     results[label] = {
         "threshold": round(float(threshold), 3),
         "TP": tp,
         "FN": fn,
         "FP": fp,
         "TN": tn,
-        "sensitivity": tp / (tp + fn) if (tp + fn) else np.nan,
-        "specificity": tn / (tn + fp) if (tn + fp) else np.nan,
-        "precision": tp / (tp + fp) if (tp + fp) else np.nan,
-        "youden_J": (
-            (tp / (tp + fn) + tn / (tn + fp) - 1) if (tp + fn) and (tn + fp) else np.nan
-        ),
+        "sensitivity": round(sensitivity, 3),
+        "specificity": round(specificity, 3),
+        "precision": round(precision, 3),
+        "F1": round(f1, 3),
+        "youden_J": round(sensitivity + specificity - 1, 3),
     }
     return results[label]
 
 
-## ---------------------------------------------------------------------------
-## 1. Target precision = 0.5
-## ---------------------------------------------------------------------------
-
-threshold_precision, beta_precision = find_optimal_threshold_beta(
-    y_valid,
-    y_prob_valid,
-    target_metric="precision",
-    target_score=0.5,
-    beta_value_range=np.linspace(0.01, 4, 40),
-    threshold_value_range=[0.2, 1],
-    delta=0.05,
-)
-
-model.threshold["roc_auc"] = threshold_precision
-metrics_precision = model.return_metrics(
-    X_valid, y_valid, optimal_threshold=True, model_metrics=True
-)
-evaluate("precision target 0.50", threshold_precision)
-
-## ---------------------------------------------------------------------------
-## 2. Target recall = 0.8
-## ---------------------------------------------------------------------------
-
-threshold_recall, beta_recall = find_optimal_threshold_beta(
-    y_valid,
-    y_prob_valid,
-    target_metric="recall",
-    target_score=0.8,
-    beta_value_range=np.linspace(0.01, 4, 40),
-    threshold_value_range=[0.3, 0.7],
-    delta=0.08,
-)
-
-model.threshold["roc_auc"] = threshold_recall
-metrics_recall = model.return_metrics(
-    X_valid, y_valid, optimal_threshold=True, model_metrics=True
-)
-evaluate("recall target 0.80", threshold_recall)
-
-## ---------------------------------------------------------------------------
-## 3. Youden's J
-## ---------------------------------------------------------------------------
-## No target score and no beta. The cut-point maximizing sensitivity +
-## specificity - 1 is read straight off the ROC curve, so nothing has to be
-## guessed in advance and re-run.
-
-threshold_youden, beta_youden = find_optimal_threshold_youden(
-    y_valid,
-    y_prob_valid,
-    threshold_value_range=np.arange(0, 1, 0.01),
-)
-
-model.threshold["roc_auc"] = threshold_youden
-metrics_youden = model.return_metrics(
-    X_valid, y_valid, optimal_threshold=True, model_metrics=True
-)
+evaluate("F-beta sweep", threshold_fbeta)
 evaluate("Youden's J", threshold_youden)
-
-################################################################################
-## Comparison
-################################################################################
 
 comparison = pd.DataFrame(results).T
 comparison.index.name = "criterion"
@@ -213,55 +175,91 @@ comparison.index.name = "criterion"
 print("\n" + "=" * 78)
 print("Threshold selected on validation, evaluated on test")
 print("=" * 78)
-print(f"validation prevalence: {prevalence:.4f}")
-print(f"test AUC             : {roc_auc_score(y_test, y_prob_test):.4f}")
-print(f"test avg precision   : {average_precision_score(y_test, y_prob_test):.4f}")
+print(f"validation prevalence : {prevalence:.4f}")
+print(f"test AUC              : {roc_auc_score(y_test, y_prob_test):.4f}")
+print(f"test average precision: {average_precision_score(y_test, y_prob_test):.4f}")
 print()
 print(comparison.to_string())
+
+################################################################################
+## What each criterion is actually optimizing
+################################################################################
+## F1 rises with TP and falls with FP and FN. TN appears nowhere in it, so the
+## criterion is blind to how the model handles the majority class. Youden's J
+## carries specificity, which is TN / (TN + FP), so the negative class is
+## weighted equally with the positive one.
+
 print()
-print(f"beta (precision target): {beta_precision}")
-print(f"beta (recall target)   : {beta_recall}")
-print(f"beta (Youden)          : {beta_youden}   <- none required")
+print("-" * 78)
+print("F1  = 2TP / (2TP + FP + FN)          <- TN absent")
+print("J   = TP/(TP+FN) + TN/(TN+FP) - 1    <- TN present")
+print("-" * 78)
+
+diff = abs(threshold_fbeta - threshold_youden)
+if diff < 0.02:
+    print(
+        f"\nThe two criteria agree to within {diff:.3f} on this cohort. "
+        "Convergence between independent criteria is a useful check on the "
+        "operating point."
+    )
+else:
+    print(
+        f"\nThe two criteria differ by {diff:.3f}. "
+        f"F-beta favours the positive class; Youden balances both."
+    )
 
 ################################################################################
 ## Threshold sweep
 ################################################################################
-## Plotting the metrics against threshold shows where each criterion landed,
-## and whether it sits in a stable region of the curve or in the ragged tail
-## where one or two patients move the numbers around.
 
 grid = np.arange(0.01, 1.0, 0.01)
-sens, spec, prec = [], [], []
+sens, spec, f1s = [], [], []
 for t in grid:
     y_hat = (y_prob_test > t).astype(int)
     tn, fp, fn, tp = confusion_matrix(y_test, y_hat, labels=[0, 1]).ravel()
-    sens.append(tp / (tp + fn) if (tp + fn) else np.nan)
-    spec.append(tn / (tn + fp) if (tn + fp) else np.nan)
-    prec.append(tp / (tp + fp) if (tp + fp) else np.nan)
+    se = tp / (tp + fn) if (tp + fn) else np.nan
+    sp = tn / (tn + fp) if (tn + fp) else np.nan
+    pr = tp / (tp + fp) if (tp + fp) else np.nan
+    sens.append(se)
+    spec.append(sp)
+    f1s.append(2 * pr * se / (pr + se) if pr and se else np.nan)
 
-plt.figure(figsize=(10, 6))
-plt.plot(grid, sens, label="Sensitivity")
-plt.plot(grid, spec, label="Specificity")
-plt.plot(grid, prec, label="Precision")
+j_curve = [se + sp - 1 for se, sp in zip(sens, spec)]
 
-for label, style in [
-    ("precision target 0.50", ":"),
-    ("recall target 0.80", "-."),
-    ("Youden's J", "--"),
-]:
-    plt.axvline(
-        results[label]["threshold"],
-        linestyle=style,
-        color="black",
-        alpha=0.7,
-        label=f"{label} ({results[label]['threshold']:.2f})",
-    )
+fig, ax = plt.subplots(figsize=(10, 6))
+ax.plot(grid, sens, label="Sensitivity", alpha=0.7)
+ax.plot(grid, spec, label="Specificity", alpha=0.7)
+ax.plot(grid, f1s, label="F1", linewidth=2)
+ax.plot(grid, j_curve, label="Youden's J", linewidth=2)
 
-plt.axvline(prevalence, color="grey", alpha=0.4, label=f"prevalence ({prevalence:.2f})")
-plt.xlabel("Threshold")
-plt.ylabel("Metric")
-plt.title("Operating point selected by each criterion")
-plt.legend(loc="best", fontsize=8)
-plt.grid(alpha=0.3)
+ax.axvline(
+    threshold_fbeta,
+    linestyle="--",
+    color="black",
+    alpha=0.8,
+    label=f"F-beta sweep ({threshold_fbeta:.2f})",
+)
+ax.axvline(
+    threshold_youden,
+    linestyle=":",
+    color="black",
+    alpha=0.8,
+    label=f"Youden's J ({threshold_youden:.2f})",
+)
+ax.axvline(
+    prevalence,
+    color="grey",
+    alpha=0.4,
+    label=f"prevalence ({prevalence:.2f})",
+)
+
+ax.set_xlabel("Threshold")
+ax.set_ylabel("Metric")
+ax.set_title("F-beta sweep vs Youden's J")
+ax.legend(loc="best", fontsize=9)
+ax.grid(alpha=0.3)
 plt.tight_layout()
+fig.savefig(IMAGES_DIR / "fbeta_vs_youden.png", dpi=300, bbox_inches="tight")
+print(f"\nSaved: {IMAGES_DIR / 'fbeta_vs_youden.png'}")
+
 plt.show()

--- a/src/model_tuner/threshold_optimization.py
+++ b/src/model_tuner/threshold_optimization.py
@@ -125,3 +125,59 @@ def find_optimal_threshold_beta(
                 )
 
             threshold = None
+
+
+def find_optimal_threshold_youden(
+    y: Union[np.ndarray, List[int]],
+    y_proba: Union[np.ndarray, List[float]],
+    threshold_value_range: np.ndarray = np.arange(0, 1, 0.01),
+) -> Tuple[float, None]:
+    """
+    Find the threshold maximizing Youden's J statistic (sensitivity +
+    specificity - 1).
+
+    Unlike F-beta tuning, this requires no target score and no beta value.
+    Returns beta as None for signature compatibility with
+    find_optimal_threshold_beta.
+
+    Parameters:
+        y (array-like): True binary labels.
+        y_proba (array-like): Predicted probabilities.
+        threshold_value_range (array-like): Range of thresholds to evaluate.
+
+    Returns:
+        tuple: (optimal threshold, None)
+
+    Raises:
+        ValueError: If y or y_proba are empty.
+    """
+    y = np.asarray(y).ravel()
+    y_proba = np.asarray(y_proba).ravel()
+
+    if not y.size:
+        raise ValueError("y cannot be empty.")
+    if not y_proba.size:
+        raise ValueError("y_proba cannot be empty.")
+
+    n_pos = (y == 1).sum()
+    n_neg = (y == 0).sum()
+    if n_pos == 0 or n_neg == 0:
+        raise ValueError("y must contain both classes to compute Youden's J.")
+
+    # Vectorized: (n_thresholds, n_samples)
+    preds = y_proba[None, :] > threshold_value_range[:, None]
+
+    tp = (preds & (y == 1)[None, :]).sum(axis=1)
+    fp = (preds & (y == 0)[None, :]).sum(axis=1)
+
+    sensitivity = tp / n_pos
+    specificity = 1 - (fp / n_neg)
+    j = sensitivity + specificity - 1
+
+    best = int(np.argmax(j))
+    threshold = float(threshold_value_range[best])
+
+    print(f"Found optimal threshold via Youden's J: {threshold}")
+    print(f"Sensitivity: {sensitivity[best]:.3f}, Specificity: {specificity[best]:.3f}")
+
+    return threshold, None

--- a/unittests/test_threshold_optimization.py
+++ b/unittests/test_threshold_optimization.py
@@ -3,9 +3,9 @@ import pytest
 from src.model_tuner.threshold_optimization import (
     threshold_tune,
     find_optimal_threshold_beta,
+    find_optimal_threshold_youden,
 )
 import pandas as pd
-
 
 empty_inputs = [
     (np.array([]), np.array([0.1, 0.2, 0.3]), "y"),
@@ -13,6 +13,33 @@ empty_inputs = [
     (pd.DataFrame(), pd.Series([0.1, 0.2, 0.3]), "y"),
     (pd.Series([0, 1, 0]), pd.DataFrame(), "y_proba"),
 ]
+
+single_class_inputs = [
+    np.zeros(20, dtype=int),
+    np.ones(20, dtype=int),
+]
+
+
+@pytest.fixture
+def separable_data():
+    """Perfectly separable data with a known ideal cut-point at 0.5."""
+    y = np.array([0] * 50 + [1] * 50)
+    y_proba = np.concatenate([np.full(50, 0.2), np.full(50, 0.8)])
+    return y, y_proba
+
+
+@pytest.fixture
+def imbalanced_data():
+    """10% prevalence with signal, the setting Youden is intended for."""
+    rng = np.random.default_rng(0)
+    y = np.zeros(1000, dtype=int)
+    y[:100] = 1
+    y_proba = np.where(
+        y == 1,
+        rng.beta(5, 5, size=1000),
+        rng.beta(2, 8, size=1000),
+    )
+    return y, y_proba
 
 
 @pytest.fixture
@@ -147,6 +174,190 @@ def test_threshold_strict_greater_than_behavior():
     expected_pred = np.array([0, 0, 1])
 
     np.testing.assert_array_equal(y_pred, expected_pred)
+
+
+def _youden_j(y, y_proba, threshold):
+    """Reference implementation used to check the optimizer's choice."""
+    y_pred = (y_proba > threshold).astype(int)
+    tp = np.sum((y_pred == 1) & (y == 1))
+    fn = np.sum((y_pred == 0) & (y == 1))
+    tn = np.sum((y_pred == 0) & (y == 0))
+    fp = np.sum((y_pred == 1) & (y == 0))
+    sensitivity = tp / (tp + fn) if (tp + fn) else 0.0
+    specificity = tn / (tn + fp) if (tn + fp) else 0.0
+    return sensitivity + specificity - 1
+
+
+def test_find_optimal_threshold_youden(sample_data):
+    """Test Youden threshold selection with valid input."""
+    y, y_proba = sample_data
+    threshold, beta = find_optimal_threshold_youden(y, y_proba)
+
+    assert 0 <= threshold <= 1, "Threshold should be within [0,1]"
+    assert beta is None, "Youden's J requires no beta; None expected"
+
+
+def test_youden_returns_none_beta_for_signature_compatibility(sample_data):
+    """The two-tuple shape must match find_optimal_threshold_beta."""
+    y, y_proba = sample_data
+    result = find_optimal_threshold_youden(y, y_proba)
+
+    assert isinstance(result, tuple), "Should return a tuple"
+    assert len(result) == 2, "Should return (threshold, beta)"
+    assert result[1] is None
+
+
+def test_youden_requires_no_target_score(sample_data):
+    """Unlike the beta search, no target_metric or target_score is needed."""
+    y, y_proba = sample_data
+    threshold, _ = find_optimal_threshold_youden(y, y_proba)
+
+    assert isinstance(threshold, float)
+
+
+def test_youden_maximizes_j(sample_data):
+    """The returned threshold must maximize J over the search grid."""
+    y, y_proba = sample_data
+    grid = np.arange(0, 1, 0.01)
+
+    threshold, _ = find_optimal_threshold_youden(y, y_proba, threshold_value_range=grid)
+
+    best_j = _youden_j(y, y_proba, threshold)
+    for candidate in grid:
+        assert _youden_j(y, y_proba, candidate) <= best_j + 1e-12, (
+            f"Threshold {candidate} yields a higher J than the selected " f"{threshold}"
+        )
+
+
+def test_youden_perfect_separation(separable_data):
+    """With a clean gap, the cut-point must fall inside it."""
+    y, y_proba = separable_data
+    threshold, _ = find_optimal_threshold_youden(y, y_proba)
+
+    assert 0.2 <= threshold < 0.8, "Threshold should land in the separating gap"
+    assert _youden_j(y, y_proba, threshold) == pytest.approx(
+        1.0
+    ), "Perfect separation should give J = 1"
+
+
+def test_youden_imbalanced_gives_usable_operating_point(imbalanced_data):
+    """
+    On a low-prevalence problem the selected point should be usable, i.e. it
+    should not collapse to predicting the majority class everywhere.
+    """
+    y, y_proba = imbalanced_data
+    threshold, _ = find_optimal_threshold_youden(y, y_proba)
+
+    y_pred = (y_proba > threshold).astype(int)
+    tp = np.sum((y_pred == 1) & (y == 1))
+    fn = np.sum((y_pred == 0) & (y == 1))
+    sensitivity = tp / (tp + fn)
+
+    assert y_pred.sum() > 0, "Model must flag at least some positives"
+    assert (
+        sensitivity > 0.5
+    ), f"Youden should give a usable sensitivity; got {sensitivity:.3f}"
+
+
+def test_youden_custom_threshold_range(sample_data):
+    """The returned threshold must come from the supplied grid."""
+    y, y_proba = sample_data
+    custom_thresholds = np.linspace(0.2, 0.8, 10)
+
+    threshold, beta = find_optimal_threshold_youden(
+        y, y_proba, threshold_value_range=custom_thresholds
+    )
+
+    assert threshold in custom_thresholds, "Threshold should be from the custom range"
+    assert (
+        min(custom_thresholds) <= threshold <= max(custom_thresholds)
+    ), "Threshold outside custom bounds"
+    assert beta is None
+
+
+def test_youden_accepts_pandas_input(sample_data):
+    """Series and single-column DataFrame inputs must behave like arrays."""
+    y, y_proba = sample_data
+
+    t_array, _ = find_optimal_threshold_youden(y, y_proba)
+    t_series, _ = find_optimal_threshold_youden(pd.Series(y), pd.Series(y_proba))
+    t_frame, _ = find_optimal_threshold_youden(pd.DataFrame(y), pd.DataFrame(y_proba))
+
+    assert t_array == t_series == t_frame
+
+
+def test_youden_is_deterministic(sample_data):
+    """Repeated calls on identical input must return the same threshold."""
+    y, y_proba = sample_data
+    first, _ = find_optimal_threshold_youden(y, y_proba)
+    second, _ = find_optimal_threshold_youden(y, y_proba)
+
+    assert first == second
+
+
+@pytest.mark.parametrize("y, y_proba, which_empty", empty_inputs)
+def test_youden_empty_input(y, y_proba, which_empty):
+    """Empty y or y_proba must raise, whichever container type."""
+    with pytest.raises(ValueError):
+        find_optimal_threshold_youden(y, y_proba)
+
+
+@pytest.mark.parametrize("y", single_class_inputs)
+def test_youden_single_class(y):
+    """J is undefined when one class is absent; must raise, not return NaN."""
+    y_proba = np.linspace(0, 1, len(y))
+
+    with pytest.raises(ValueError, match="both classes"):
+        find_optimal_threshold_youden(y, y_proba)
+
+
+def test_youden_strict_greater_than_behavior():
+    """
+    Predictions must use a strict '>' comparison, matching threshold_tune.
+    A score exactly equal to the threshold is a negative prediction.
+    """
+    y = np.array([0, 1, 1])
+    y_proba = np.array([0.4, 0.5, 0.6])
+
+    threshold, _ = find_optimal_threshold_youden(
+        y, y_proba, threshold_value_range=np.array([0.5])
+    )
+
+    y_pred = (y_proba > threshold).astype(int)
+    np.testing.assert_array_equal(y_pred, np.array([0, 0, 1]))
+
+
+def test_youden_returns_python_float(sample_data):
+    """Threshold should be a plain float, not a numpy scalar."""
+    y, y_proba = sample_data
+    threshold, _ = find_optimal_threshold_youden(y, y_proba)
+
+    assert type(threshold) is float
+
+
+def test_youden_handles_list_input():
+    """Plain Python lists must be accepted."""
+    y = [0, 0, 1, 1]
+    y_proba = [0.1, 0.2, 0.8, 0.9]
+
+    threshold, beta = find_optimal_threshold_youden(y, y_proba)
+
+    assert 0 <= threshold <= 1
+    assert beta is None
+
+
+def test_youden_all_scores_identical():
+    """
+    Degenerate case: no threshold separates anything, so J is 0 everywhere.
+    The call must still return a threshold in range rather than raise.
+    """
+    y = np.array([0, 0, 1, 1])
+    y_proba = np.full(4, 0.5)
+
+    threshold, beta = find_optimal_threshold_youden(y, y_proba)
+
+    assert 0 <= threshold <= 1
+    assert beta is None
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Youden and F1 aren’t the same criterion. F1 ignores true negatives entirely, Youden weights sensitivity and specificity equally, and Youden is the conventional operating-point choice in clinical prediction papers.

- New function in `threshold_optimization.py`, exported from `__init__.py`. Returns `(threshold, None)` so the tuple shape matches `find_optimal_threshold_beta` and existing call sites don't need special-casing. Beta doesn't exist for Youden, hence the `None`.

- Vectorized over the threshold grid, so it's a single boolean broadcast instead of a loop. Uses strict `>` to match `threshold_tune`.

- Raises if either input is empty, and raises if `y` has only one class, since J is undefined there. Returning `NaN` instead would let a broken threshold leak downstream into whatever's consuming it.

Nothing existing changes. It's additive.

### Tests

19 in `test_threshold_optimization.py`. The three that matter:

- `test_youden_maximizes_j` reimplements J independently and checks nothing in the grid beats what got returned
- `test_youden_imbalanced_gives_usable_operating_point` runs a 10% prevalence fixture and asserts the thing actually flags positives, which is the regression guard for the case above
- `test_youden_single_class` checks it raises instead of quietly handing back NaN

- Add `threshold_testing_rf_youden.py` testing script:

```text
Threshold after grid search (uncalibrated): 0.260
Fitting model with best params and tuning for best threshold ...
100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 2/2 [00:00<00:00,  9.85it/s]
roc_auc after calibration: 0.9509882478632479
Threshold after calibration (F-beta sweep) : 0.110
Found optimal threshold via Youden's J: 0.22
Sensitivity: 0.904, Specificity: 0.886
Threshold from Youden's J                  : 0.220

==============================================================================
Threshold selected on validation, evaluated on test
==============================================================================
validation prevalence : 0.2430
test AUC              : 0.9346
test average precision: 0.8103

              threshold    TP    FN    FP     TN  sensitivity  specificity  precision     F1  youden_J
criterion                                                                                             
F-beta sweep       0.11  93.0  11.0  52.0  272.0        0.894        0.840      0.641  0.747     0.734
Youden's J         0.22  86.0  18.0  37.0  287.0        0.827        0.886      0.699  0.758     0.713

------------------------------------------------------------------------------
F1  = 2TP / (2TP + FP + FN)          <- TN absent
J   = TP/(TP+FN) + TN/(TN+FP) - 1    <- TN present
------------------------------------------------------------------------------
```

<img width="2970" height="1765" alt="image" src="https://github.com/user-attachments/assets/143122e1-1a66-48ff-a060-1b38163fc152" />
